### PR TITLE
Add copyright message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-## folio-data-anonymization
+# folio-data-anonymization
+
+Copyright (C) 2025 The Open Library Foundation
+
+This software is distributed under the terms of the Apache License,
+Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
+
+## Introduction
 Folio Data Anonymization is a service that anonymizes or masks patron data in library records to ensure privacy protection.
 
 ## Environment Variables 


### PR DESCRIPTION
Adds a specific note to the README that this project's copyright belongs to the OLF.