### PR TITLE
Adds json configuration for anonymized user data.

### DIFF
--- a/plugins/config/user_associated_tables.json
+++ b/plugins/config/user_associated_tables.json
@@ -1,0 +1,82 @@
+[
+  {
+    "table_name": "mod_audit.circulation_logs",
+    "anonymize": {
+      "jsonb": [
+        "source",
+        "userBarcode"
+      ]
+    }
+  },
+  {
+    "table_name": "mod_circulation_storage.request",
+    "anonymize": {
+      "jsonb": [
+        "requester, barcode",
+        "requester, lastName",
+        "requester, firstName",
+        "requester, middleName",
+        "proxy, barcode",
+        "proxy, lastName",
+        "proxy, firstName",
+        "proxy, middleName"
+      ]
+    },
+    "set_to_empty": {
+      "jsonb": [
+        "patronComments"
+      ]
+    }
+  },
+  {
+    "table_name": "mod_courses.coursereserves_courselistings",
+    "anonymize": {
+      "jsonb": [
+        {
+          "instructorObjects": [
+            "name",
+            "barcode"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "table_name": "mod_courses.coursereserves_instructors",
+    "anonymize": {
+      "jsonb": [
+        "name",
+        "barcode"
+      ]
+    }
+  },
+  {
+    "table_name": "mod_users.users",
+    "anonymize": {
+      "jsonb": [
+        {
+          "addresses": [
+            "countryId",
+            "addressLine1",
+            "addressLine2",
+            "city",
+            "region",
+            "postalCode"
+          ]
+        },
+        "personal, pronouns",
+        "personal, lastName",
+        "personal, firstName",
+        "personal, middleName",
+        "personal, preferredFirstName",
+        "personal, email",
+        "personal, phone",
+        "personal, mobilePhone",
+        "personal, dateOfBirth",
+        "username",
+        "barcode",
+        "externalSystemId"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Closes https://folio-org.atlassian.net/browse/DANON-17
Jeremy and I paired on figuring out the "best" way to convey that some JSONB fields we need to anonymize are objects within an array. For example, we need to iterate through instructorObjects and anonymize the name and barcode fields in each:
```
{
    "table_name": "mod_courses.coursereserves_courselistings",
    "anonymize": {
      "jsonb": [
        {
          "instructorObjects": [
            "name",
            "barcode"
          ]
        }
      ]
    }
}
```
I guess we'll see how far we get with that kind of structure.