### PR TITLE
Updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ data:
   airflow-jwt-secret-key: {any JWT key}
 ```
 
+Instructions on generating a Fernet key can be found at [How-to Guides: Securing Connections](https://airflow.apache.org/docs/apache-airflow/1.10.4/howto/secure-connections.html?highlight=fernet)
+Example:
+```
+poetry run python3
+>>> from cryptography.fernet import Fernet
+>>> fernet_key= Fernet.generate_key()
+>>> decoded_fernet_key = fernet_key.decode()
+echo -n $decoded_fernet_key | base64
+```
+
 Then apply it using `kubectl -n $namespace apply -f secret.yaml`
 
 ## Install Apache Airflow in a Kubernetes cluster 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ With [Docker Desktop](https://docs.docker.com/desktop/), [Helm](https://helm.sh/
 
 Then, using Helm:
 ```
-helm --namespace $NAMESPACE install --set ingress.enabled=true --set ingress.hostname=$HOSTNAME -f airflow-values.yaml airflow oci://registry-1.docker.io/bitnamicharts/airflow
+helm --namespace $NAMESPACE install -f airflow-values.yaml airflow oci://registry-1.docker.io/bitnamicharts/airflow
 ```
 
 To upgrade airflow release, do:

--- a/README.md
+++ b/README.md
@@ -59,5 +59,11 @@ With [Docker Desktop](https://docs.docker.com/desktop/), [Helm](https://helm.sh/
 
 Then, using Helm:
 ```
-helm --namespace $NAMESPACE install -f airflow-values.yaml airflow-$NAMESPACE oci://registry-1.docker.io/bitnamicharts/airflow
+helm --namespace $NAMESPACE install --set ingress.enabled=true --set ingress.hostname=$HOSTNAME -f airflow-values.yaml airflow oci://registry-1.docker.io/bitnamicharts/airflow
+```
+
+To upgrade airflow release, do:
+```
+export PASSWORD=$(kubectl get secret --namespace $NAMESPACE airflow-postgresql -o jsonpath="{.data.password}" | base64 -d)
+helm --namespace $NAMESPACE upgrade --set global.postgresql.auth.password=$PASSWORD -f airflow-values.yaml airflow oci://registry-1.docker.io/bitnamicharts/airflow
 ```


### PR DESCRIPTION
- changes helm chart release name to remove ${namespace}
- adds information for generating a Fernet key and base65-encoding it for adding to the secrets.yaml file

This PR was meant to address ticket https://folio-org.atlassian.net/browse/DANON-16. After fixing the Fernet key value in the secret, I was able to create an airflow Connection to the folio postgres database. I have not been able to confirm we actually can connect to it from airflow running in the k8s cluster. Despite this, the updates to the README are pertinent to correct airflow deployment.