### PR TITLE
[DRAFT] Finishes anonymize_data DAG 

### DIFF
--- a/folio_data_anonymization/dags/anonymize_data.py
+++ b/folio_data_anonymization/dags/anonymize_data.py
@@ -4,8 +4,11 @@ import logging
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.decorators import task
+from airflow.decorators import task, task_group
+from airflow.operators.empty import EmptyOperator
 
+
+from folio_data_anonymization.plugins.utils import fake_jsonb, update_row
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +51,44 @@ with DAG(
         return {"config": table_config, "data": data}
 
     @task
-    def anonymize_row(**kwargs):
-        """
-        Anonymize the data
-        """
-        pass
+    def get_tuples(**kwargs):
+        return kwargs["payload"]["data"]
 
-    @task  # sql update the data
-    def update_table():
-        pass
+    @task_group(group_id="row_processing")
+    def row_processing_group(**kwargs):
+        config = kwargs["payload"]["config"]
+        data = kwargs["data"]
 
+        @task
+        def anonymize_row(**kwargs) -> dict:
+            """
+            Anonymize the data
+            """
+            data: tuple = kwargs["data"]
+            config: dict = kwargs["config"]
 
-payload = setup()
-anonymize_row().partial(config=payload["config"]).expand(data=payload["data"])  # type: ignore # noqa: E501
+            return {
+                "id": data[0],
+                "jsonb": fake_jsonb(data[1], config),
+            }
+
+        @task
+        def update_table(**kwargs):
+            """
+            Updates jsonb in the database with faked data
+            """
+            payload = kwargs["payload"]
+            config = kwargs["config"]
+            uuid = payload["id"]
+            jsonb = payload["jsonb"]
+            schema_table = config["table_name"]
+            update_row(id=uuid, jsonb=jsonb, schema_table=schema_table)
+
+        mod_data = anonymize_row(data=data, config=config)
+        update_table(payload=mod_data, config=config)
+
+    payload = setup()
+    all_rows = get_tuples(payload=payload)
+    row_processing_group.partial(payload=payload).expand(
+        data=all_rows
+    ) >> EmptyOperator(task_id="Finished")

--- a/folio_data_anonymization/plugins/sql/update_jsonb.sql
+++ b/folio_data_anonymization/plugins/sql/update_jsonb.sql
@@ -1,0 +1,1 @@
+UPDATE %(schema_table)s SET jsonb=%(jsonb)s WHERE id=%(uuid)s;

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,33 @@ import copy
 import json
 import pathlib
 
-from folio_data_anonymization.plugins.utils import fake_jsonb
+import pydantic
+import pytest
+
+from folio_data_anonymization.plugins.utils import fake_jsonb, update_row
+
+
+class MockSQLExecuteQueryOperator(pydantic.BaseModel):
+    def execute(self, sql):
+        return []
+
+
+class MockFailedExecuteQueryOperator(pydantic.BaseModel):
+    def execute(self, sql):
+        raise ValueError(f"Cannot execute {sql}")
+
+
+@pytest.fixture
+def mock_get_current_context(monkeypatch, mocker):
+    def _context():
+        context = mocker.stub(name="context")
+        context.get = lambda *args: {}
+        return context
+
+    monkeypatch.setattr(
+        'folio_data_anonymization.plugins.utils.get_current_context',
+        _context,
+    )
 
 
 def test_org_fake_jsonb(configs):
@@ -47,3 +73,25 @@ def test_user_fake_jsonb(configs):
         != original_user["personal"]["addresses"][0]["addressLine1"]
     )
     assert len(user.get('customFields')) == 0
+
+
+def test_update_row(mock_get_current_context, mocker):
+    mocker.patch(
+        'folio_data_anonymization.plugins.utils.SQLExecuteQueryOperator',
+        return_value=MockSQLExecuteQueryOperator(),
+    )
+    uuid = "f9d5a80e-3b51-11f0-a1d0-5a0f9a6cb774"
+    jsonb = {"name": "George Fox"}
+    schema_table = "diku_mod_users.users"
+    assert update_row(id=uuid, jsonb=jsonb, schema_table=schema_table)
+
+
+def test_failed_update_row(mock_get_current_context, mocker):
+    mocker.patch(
+        'folio_data_anonymization.plugins.utils.SQLExecuteQueryOperator',
+        return_value=MockFailedExecuteQueryOperator(),
+    )
+    uuid = "c76983b2-3b52-11f0-a1d0-5a0f9a6cb774"
+    jsonb = {"name": "The Giant Hen House"}
+    schema_table = "diku_mod_organizations.organizations"
+    assert update_row(id=uuid, jsonb=jsonb, schema_table=schema_table) == False


### PR DESCRIPTION
Adds a new `task_group` to `anonymize_data` DAG that takes each data row, anonymizes any `jsonb` fields based on the incoming config dict, and then updates the `jsonb` based on the UUID.

In draft state because still needs to be tested on K8s cluster. 