### PR TITLE
Commit sql transactions that use sql pool

### DIFF
--- a/folio_data_anonymization/dags/anonymize_data.py
+++ b/folio_data_anonymization/dags/anonymize_data.py
@@ -1,18 +1,30 @@
 """Anonymize Tables in FOLIO based on Configuration File."""
 
-import json
 import logging
 from datetime import timedelta
 
-from airflow import DAG
-from airflow.decorators import task
+from airflow.decorators import dag
 from airflow.operators.empty import EmptyOperator
 
 
 try:
-    from plugins.git_plugins.utils import fake_jsonb, update_row
+    from plugins.git_plugins.anonymize import (
+        anonymize_payload,
+        anonymize_row_update_table,
+        payload_tuples,
+    )
 except (ImportError, ModuleNotFoundError):
-    from folio_data_anonymization.plugins.utils import fake_jsonb, update_row
+    from folio_data_anonymization.plugins.anonymize import (
+        anonymize_payload,
+        anonymize_row_update_table,
+        payload_tuples,
+    )
+
+try:
+    from plugins.git_plugins.sql_pool import SQLPool
+except (ImportError, ModuleNotFoundError):
+    from folio_data_anonymization.plugins.sql_pool import SQLPool
+
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +37,7 @@ default_args = {
 }
 
 
-with DAG(
+@dag(
     "anonymize_data",
     default_args=default_args,
     schedule=None,
@@ -34,50 +46,17 @@ with DAG(
     render_template_as_native_obj=True,
     max_active_runs=1,
     max_active_tasks=10,
-) as dag:
+)
+def anonymize():
+    connection_pool = SQLPool().pool()
 
-    @task
-    def prepare_payload(**kwargs) -> dict:
-        """
-        Setup task to prepare the environment for anonymization.
-        select_tables DAG will pass:
-        conf = {"tenant": "",
-                "table_config":
-                    {"table_name": "diku_mod_users.users",
-                        "anonymize": {"jsonb": []}},
-                        "set_to_empty": {"jsonb": []}},
-                "data": (('id1', 'jsonb1'), ('id2', 'jsonb2'),...n)
-                }
-        """
-        params = kwargs.get("params", {})
-        table_config: dict = params.get("table_config", {})
-        data: list = params.get("data", [])
-        tenant = params.get("tenant", "diku")
-        logger.info(f"Anonymizing data for tenant {tenant}")
-        logger.info(
-            f"Begin processing {len(data)} records from {table_config.get("table_name")}"  # noqa
-        )
-        return {"config": table_config, "data": data}
+    payload = anonymize_payload()
 
-    @task
-    def get_tuples(**kwargs):
-        return kwargs["payload"]["data"]
+    all_rows = payload_tuples(payload=payload)
 
-    @task
-    def anonymize_row_update_table(**kwargs):
-        data: tuple = kwargs["data"]
-        config: dict = kwargs["payload"]["config"]
-        logger.info(f"Anonymizing record {data[0]}")
+    anonymize_row_update_table.partial(
+        payload=payload, connection_pool=connection_pool
+    ).expand(data=all_rows) >> EmptyOperator(task_id="Finished")
 
-        data_dict = json.loads(data[1])
-        fake_json = fake_jsonb(data_dict, config)
-        logger.info(f"Processed data: {fake_json}")
-        update_row(id=data[0], jsonb=fake_json, schema_table=config["table_name"])
 
-    payload = prepare_payload()
-
-    all_rows = get_tuples(payload=payload)
-
-    anonymize_row_update_table.partial(payload=payload).expand(
-        data=all_rows
-    ) >> EmptyOperator(task_id="Finished")
+anonymize()

--- a/folio_data_anonymization/plugins/anonymize.py
+++ b/folio_data_anonymization/plugins/anonymize.py
@@ -1,0 +1,58 @@
+import logging
+
+from airflow.decorators import task
+
+try:
+    from plugins.git_plugins.utils import fake_jsonb, update_row
+except (ImportError, ModuleNotFoundError):
+    from folio_data_anonymization.plugins.utils import fake_jsonb, update_row
+
+logger = logging.getLogger(__name__)
+
+
+@task
+def anonymize_payload(**kwargs):
+    """
+    Setup task to prepare the environment for anonymization.
+    select_tables DAG will pass:
+    conf = {"tenant": "",
+            "table_config":
+                {"table_name": "diku_mod_users.users",
+                    "anonymize": {"jsonb": []}},
+                    "set_to_empty": {"jsonb": []}},
+            "data": (('id1', 'jsonb1'), ('id2', 'jsonb2'),...n)
+            }
+    """
+    params = kwargs.get("params", {})
+    table_config: dict = params.get("table_config", {})
+    data: list = params.get("data", [])
+    tenant = params.get("tenant", "diku")
+    logger.info(f"Anonymizing data for tenant {tenant}")
+    logger.info(
+        f"Begin processing {len(data)} records from {table_config.get("table_name")}"  # noqa
+    )
+    return {"config": table_config, "data": data}
+
+
+@task
+def payload_tuples(**kwargs):
+    return kwargs["payload"]["data"]
+
+
+@task
+def anonymize_row_update_table(**kwargs):
+    data: tuple = kwargs["data"]
+    config: dict = kwargs["payload"]["config"]
+    connection_pool = kwargs.get("connection_pool")
+    logger.info(f"Anonymizing record {data[0]}")
+
+    fake_json = fake_jsonb(data[1], config)
+    logger.info(f"Processed data: {fake_json}")
+    conn = connection_pool.getconn()
+    update_row(
+        id=data[0],
+        jsonb=fake_json,
+        schema_table=config["table_name"],
+        connection=conn,
+    )
+    connection_pool.putconn(conn)

--- a/tests/test_anonymize_data_dag.py
+++ b/tests/test_anonymize_data_dag.py
@@ -3,59 +3,34 @@ import pathlib
 import pydantic
 import pytest
 
-from psycopg2 import Error
 
-from airflow.models import Connection
-
-from folio_data_anonymization.plugins.utils import SQLPool
-from folio_data_anonymization.plugins.sql_pool import SimpleConnectionPool
-
-from folio_data_anonymization.dags.anonymize_data import (
+from folio_data_anonymization.plugins.anonymize import (
+    anonymize_payload,
     anonymize_row_update_table,
-    prepare_payload,
-    get_tuples,
+    payload_tuples,
 )
 
 
 class MockCursor(pydantic.BaseModel):
-    def fetchall(self):
-        return mock_result_set()
+    def cursor(self):
+        return self
+
+    def commit(self):
+        return True
 
     def execute(self, sql_stmt, params):
-        if str(params["table"]) == "diku_mod_organizations.foo":
-            raise Error()
         self
 
-
-class MockConnection(pydantic.BaseModel):
-    def cursor(self):
-        return MockCursor()
+    def fetchall(self):
+        return []
 
 
 class MockPool(pydantic.BaseModel):
-    def pool(self):
-        return self
-
     def getconn(self):
-        return MockConnection()
-
-    def cursor(self):
         return MockCursor()
 
-
-class MockAirflowConnection(pydantic.BaseModel):
-    def get_connection_from_secrets(self):
-        return Connection(  # noqa
-            conn_id="postgres-folio",
-            conn_type="postgres",
-            host="example.com",
-            password="pass",
-            port=5432,
-        )
-
-
-def mock_result_set():
-    return []
+    def putconn(self, conn):
+        return True
 
 
 @pytest.fixture
@@ -85,22 +60,20 @@ def mock_dag_run(mocker, configs, mock_data):
     return dag_run
 
 
-def test_prepare_payload(mocker, mock_dag_run, caplog):
-    payload = prepare_payload.function(params=mock_dag_run.conf)
+def test_anonymize(mocker, mock_dag_run, caplog):
+    mocker.patch('folio_data_anonymization.plugins.utils.update_row', return_value=True)
+    payload = anonymize_payload.function(params=mock_dag_run.conf)
     assert payload["config"]["table_name"] == "diku_mod_users.users"
     assert "Begin processing 1 records from diku_mod_users.users" in caplog.text
-    data_tuples = get_tuples.function(payload=payload)
+
+    data_tuples = payload_tuples.function(payload=payload)
     assert data_tuples[0][0] == "925329d6-3caa-4ae0-bea8-705d70b7a51c"
     assert isinstance(json.loads(payload["data"][0][1]), dict)
 
-
-def test_anonymize_row_update_table(mocker, mock_dag_run, mock_data, caplog):
-    mocker.patch("folio_data_anonymization.plugins.utils.update_row", return_value=True)
-    mocker.patch.object(SQLPool, "connection", MockAirflowConnection)
-    mocker.patch.object(SQLPool, "pool", MockPool)
-    mocker.patch.object(SimpleConnectionPool, "getconn", MockConnection)
-
-    payload = prepare_payload.function(params=mock_dag_run.conf)
-
-    anonymize_row_update_table.function(data=mock_data[0], payload=payload)
-    assert "stanford" not in caplog.text
+    # make sure user object is a dict for test...
+    user_dict = json.loads(data_tuples[0][1])
+    tuples = (data_tuples[0][0], user_dict)
+    anonymize_row_update_table.function(
+        data=tuples, payload=payload, connection_pool=MockPool()
+    )
+    assert "Processed data" in caplog.text


### PR DESCRIPTION
SQL pool needs to be defined at the DAG Leven and passed down to each task in order to take advantage of the pool connections.

Moved anonymize functions to a plugin because it was not possible to test the DAG functions directly while using the SQLPool (It wanted to instantiate a connection and was not able to find an airflow Connection entry, and it was not possible to mock it because it happened during the module import).