### PR TITLE
Checks data type of JSON to set to empty

### DIFF
--- a/folio_data_anonymization/plugins/anonymize.py
+++ b/folio_data_anonymization/plugins/anonymize.py
@@ -29,7 +29,7 @@ def anonymize_payload(**kwargs):
     tenant = params.get("tenant", "diku")
     logger.info(f"Anonymizing data for tenant {tenant}")
     logger.info(
-        f"Begin processing {len(data)} records from {table_config.get("table_name")}"  # noqa
+        f"Begin processing {len(data)} records from {table_config.get('table_name')}"  # noqa
     )
     return {"config": table_config, "data": data}
 

--- a/folio_data_anonymization/plugins/select_tables.py
+++ b/folio_data_anonymization/plugins/select_tables.py
@@ -16,7 +16,7 @@ def schemas_tables(config, tenant_id) -> list:
     schemas_tables = []
     config_key = list(config.keys())[0]
     for schema_table in config[config_key]:
-        schemas_tables.append(f"{tenant_id}_{schema_table["table_name"]}")
+        schemas_tables.append(f"{tenant_id}_{schema_table['table_name']}")
 
     return schemas_tables
 

--- a/folio_data_anonymization/plugins/utils.py
+++ b/folio_data_anonymization/plugins/utils.py
@@ -22,6 +22,15 @@ faker.add_provider(Organizations)
 faker.add_provider(Users)
 
 
+def _data_type(data) -> Union[str, list, dict]:
+    if isinstance(data, list):
+        return []
+    elif isinstance(data, dict):
+        return {}
+    else:
+        return ""
+
+
 def fake_jsonb(jsonb: dict, config: dict) -> dict:
     """
     Fake the jsonb data based on the provided config.
@@ -32,7 +41,12 @@ def fake_jsonb(jsonb: dict, config: dict) -> dict:
         expr.update(jsonb, faker_function())
     for row in config.get("set_to_empty", {}).get("jsonb", []):
         expr = parse(row)
-        expr.update(jsonb, "")
+        data = [match.value for match in expr.find(jsonb)]
+        if len(data) > 0:
+            replacement_char = _data_type(data.pop())
+        else:
+            replacement_char = ""
+        expr.update(jsonb, replacement_char)
     return jsonb
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,8 +93,8 @@ def test_org_fake_jsonb(configs):
         organization["accounts"][0]["contactInfo"]
         != original_org["accounts"][0]["contactInfo"]
     )
-    assert len(organization["aliases"][0]["description"]) == 0
-    assert len(organization["accounts"][0]["description"]) == 0
+    assert organization["aliases"][0]["description"] == ""
+    assert organization["accounts"][0]["description"] == ""
 
 
 def test_user_fake_jsonb(configs):
@@ -116,7 +116,8 @@ def test_user_fake_jsonb(configs):
         user["personal"]["addresses"][0]["addressLine1"]
         != original_user["personal"]["addresses"][0]["addressLine1"]
     )
-    assert len(user.get('customFields')) == 0
+    assert isinstance(user.get("customFields"), dict)
+    assert user.get("customFields") != ""
 
 
 def test_update_row(mocker, mock_airflow_connection):


### PR DESCRIPTION
I think by checking the data type of one of the JSON fields listed as set to empty in the JSON configuration file, we'd always be certain the replacement is correct, instead of adding something to the configuration file (like maybe we think it's a string but it's really not in the data we get).