### PR TITLE
[DANON-60] Anonymization for vendor names/codes

### DIFF
--- a/src/main/java/org/folio/anonymization/controller/EntryPointController.java
+++ b/src/main/java/org/folio/anonymization/controller/EntryPointController.java
@@ -3,7 +3,6 @@ package org.folio.anonymization.controller;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.log4j.Log4j2;
-import org.folio.anonymization.domain.job.Job;
 import org.folio.anonymization.domain.job.JobBuilder;
 import org.folio.anonymization.domain.job.JobFactory;
 import org.folio.anonymization.domain.job.TenantExecutionContext;
@@ -26,6 +25,7 @@ public class EntryPointController {
   @EventListener(ApplicationReadyEvent.class)
   public void entryPoint() throws InterruptedException {
     log.info("============================");
+
     TenantExecutionContext tenant = tenantRepository.getTenantExecutionContext(
       tenantRepository.getAllTenants().get("fs09000000")
     );
@@ -34,11 +34,12 @@ public class EntryPointController {
       .map(factory -> factory.getBuilders(tenant))
       .flatMap(List::stream)
       .toList();
-    List<Job> jobs = builders.stream().map(JobBuilder::build).toList();
-    log.info("Created {} jobs", jobs.size());
+    log.info("Found {} available jobs", builders.size());
 
-    log.info("Running jobs based on temporary filter...");
-    jobs.stream().filter(job -> job.getName().contains("User agent anonymization")).forEach(Job::execute);
+    JobBuilder toTest = builders.stream().filter(b -> b.name().contains("Vendor names")).findFirst().orElseThrow();
+    toTest.configuration().stream().filter(c -> c.getKey().equals("drop-table")).forEach(s -> s.setBooleanValue(false));
+    log.info("Running job...");
+    toTest.build().execute();
 
     log.info("========== finished launching jobs ==========");
 

--- a/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
@@ -191,7 +191,7 @@ public class VendorNamesAndCodeAnonymization implements JobFactory {
               "generate-new-values-prep",
               List.of(
                 new BatchGenerationJobPart(
-                  "test",
+                  "Analyze table size for split processing",
                   tempTableStaging,
                   BATCH_SIZE,
                   "generate-new-values-regular",

--- a/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
@@ -1,0 +1,286 @@
+package org.folio.anonymization.jobs;
+
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.primaryKey;
+import static org.jooq.impl.DSL.select;
+import static org.jooq.impl.DSL.table;
+import static org.jooq.impl.DSL.unique;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.job.Job;
+import org.folio.anonymization.domain.job.JobBuilder;
+import org.folio.anonymization.domain.job.JobConfigurationProperty;
+import org.folio.anonymization.domain.job.JobFactory;
+import org.folio.anonymization.domain.job.JobPart;
+import org.folio.anonymization.domain.job.SharedExecutionContext;
+import org.folio.anonymization.domain.job.TenantExecutionContext;
+import org.folio.anonymization.jobs.templates.BatchGenerationJobPart;
+import org.folio.anonymization.jobs.templates.CreateTablePart;
+import org.folio.anonymization.jobs.templates.DropTablePart;
+import org.folio.anonymization.jobs.templates.GenerateUniqueValuesPart;
+import org.folio.anonymization.jobs.templates.InsertIntoTablePart;
+import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
+import org.folio.anonymization.util.DBUtils;
+import org.folio.anonymization.util.RandomValueUtils;
+import org.jooq.Field;
+import org.jooq.JSONB;
+import org.jooq.Table;
+import org.jooq.impl.SQLDataType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VendorNamesAndCodeAnonymization implements JobFactory {
+
+  // used for generating new names/codes
+  private static final int BATCH_SIZE = 2_000;
+
+  private static final List<FieldReference> FIELDS = List.of(
+    new FieldReference("agreements", "alternate_name", "an_name"),
+    new FieldReference("agreements", "kbart_import_job", "package_source"),
+    new FieldReference("agreements", "kbart_import_job", "package_provider"),
+    new FieldReference("agreements", "org", "org_name"),
+    new FieldReference("agreements", "package", "pkg_source"),
+    new FieldReference("copycat", "profile", "jsonb", "$.name"),
+    new FieldReference("erm_usage", "usage_data_providers", "jsonb", "$.harvestingConfig.aggregator.name"),
+    new FieldReference("erm_usage", "usage_data_providers", "jsonb", "$.harvestingConfig.aggregator.vendorCode"),
+    new FieldReference("invoice_storage", "batch_vouchers", "jsonb", "$.batchedVouchers[*].vendorName"),
+    new FieldReference("licenses", "alternate_name", "an_name"),
+    new FieldReference("licenses", "org", "org_name"),
+    new FieldReference("orders_storage", "export_history", "jsonb", "$.vendorName"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.name"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.code"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.aliases[*].value")
+  );
+
+  // used to correlate some names with some codes. Allows us to later update the names
+  // to be semantically related (e.g. anonymized code ABCD would be able to refer to Org ABCD, LLC or something)
+  private static final Map<FieldReference, FieldReference> pairedFields = Map.of(
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.name"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.code")
+  );
+
+  @Autowired
+  private SharedExecutionContext context;
+
+  @Override
+  public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
+    return List.of(
+      new JobBuilder(
+        "Vendor names/code anonymization",
+        "Replaces vendor names and codes with unique anonymized values, ensuring integrity between tables.",
+        tenant,
+        context,
+        Stream
+          .concat(
+            Stream.of(
+              new JobConfigurationProperty(
+                "create-table",
+                "Create temporary table with current and new values (disable if resuming a previous run)"
+              ),
+              new JobConfigurationProperty(
+                "drop-table",
+                "Destroy temporary table (PII will be left behind if disabled)"
+              )
+            ),
+            JobConfigurationProperty.fromFieldList(FIELDS, tenant).stream()
+          )
+          .toList(),
+        ctx -> {
+          // final contains the full [original,reference,newValue]
+          // staging contains only [original,reference]
+          // this allows us to copy from one to the other as we generate unique values
+          Table<?> tempTableFinal = table(
+            name("public", "_danon_" + ctx.tenant().tenant().id() + "_vendor_names_and_codes")
+          );
+          Table<?> tempTableStaging = table(
+            name("public", "_danon_" + ctx.tenant().tenant().id() + "_vendor_names_and_codes_staging")
+          );
+
+          Field<String> originalValue = field("original_value", SQLDataType.VARCHAR.notNull());
+          // if this row represents a name, its code will be here
+          Field<String> referenceCode = field("reference_code", SQLDataType.VARCHAR.null_());
+          Field<String> newValue = field("new_value", SQLDataType.VARCHAR.null_());
+
+          Job job = new Job(
+            ctx,
+            List.of(
+              "prepare",
+              // must be done discretely and as its own part since first inserts take priority
+              // over later ones
+              "enumerate-correlated",
+              "enumerate-independent",
+              // single job to count and spawn child generate-new-values jobs
+              "generate-new-values-prep",
+              "generate-new-values-regular",
+              // overwrite generated new values for names that have codes
+              "correlate-new-values",
+              "apply-new-values",
+              "cleanup"
+            )
+          );
+
+          if (JobConfigurationProperty.isOn(ctx.settings(), "create-table")) {
+            job.scheduleParts(
+              "prepare",
+              List.of(
+                new CreateTablePart(
+                  "Create temporary table (staging)",
+                  tempTableStaging,
+                  List.of(originalValue, referenceCode),
+                  List.of(primaryKey(originalValue)),
+                  true
+                ),
+                new CreateTablePart(
+                  "Create temporary table (final)",
+                  tempTableFinal,
+                  List.of(originalValue, referenceCode, newValue),
+                  List.of(primaryKey(originalValue), unique(newValue)),
+                  false
+                )
+              )
+            );
+            job.scheduleParts(
+              "enumerate-correlated",
+              JobConfigurationProperty
+                .getEnabledFields(ctx.settings())
+                .filter(pairedFields::containsKey)
+                .map(field -> {
+                  FieldReference pairedField = pairedFields.get(field);
+
+                  return new InsertIntoTablePart(
+                    "Enumerate correlated data from " + field.toString(),
+                    tempTableStaging,
+                    select(field("a"), field("b"))
+                      .from(
+                        select(
+                          field.field(ctx.tenant().tenant(), String.class).as("a"),
+                          pairedField.field(ctx.tenant().tenant(), String.class).as("b")
+                        )
+                          .from(field.table(ctx.tenant().tenant()))
+                      )
+                      .where(field("a").isNotNull())
+                  );
+                })
+                .toList()
+            );
+            job.scheduleParts(
+              "enumerate-independent",
+              JobConfigurationProperty
+                .getEnabledFields(ctx.settings())
+                .filter(f -> !pairedFields.containsKey(f))
+                .map(field ->
+                  new InsertIntoTablePart(
+                    "Enumerate independent data from " + field.toString(),
+                    tempTableStaging,
+                    select(field("a"))
+                      .from(
+                        select(field.field(ctx.tenant().tenant(), String.class).as("a"))
+                          .from(field.table(ctx.tenant().tenant()))
+                      )
+                      .where(field("a").isNotNull())
+                  )
+                )
+                .toList()
+            );
+            job.scheduleParts(
+              "generate-new-values-prep",
+              List.of(
+                new BatchGenerationJobPart(
+                  "test",
+                  tempTableStaging,
+                  BATCH_SIZE,
+                  "generate-new-values-regular",
+                  (cond, start, end) ->
+                    new GenerateUniqueValuesPart(
+                      "Generate values (%s-%s)".formatted(start, end),
+                      tempTableFinal,
+                      newValue,
+                      select(originalValue, referenceCode).from(tempTableStaging).where(cond),
+                      RandomValueUtils.codeLikeValueGenerator(start)
+                    )
+                )
+              )
+            );
+            job.scheduleParts(
+              "correlate-new-values",
+              List.of(new CorrelateNamesAndCodesPart(tempTableFinal, originalValue, referenceCode, newValue))
+            );
+          }
+
+          job.scheduleParts(
+            "apply-new-values",
+            JobConfigurationProperty
+              .getEnabledFields(ctx.settings())
+              .map(field ->
+                new ReplaceJSONBValuePart(
+                  "replace",
+                  field,
+                  innerField ->
+                    field(
+                      "to_jsonb(({0}))",
+                      JSONB.class,
+                      select(newValue).from(tempTableFinal).where(originalValue.eq(DBUtils.jsonbToString(innerField)))
+                    )
+                )
+              )
+              .toList()
+          );
+
+          if (JobConfigurationProperty.isOn(ctx.settings(), "drop-table")) {
+            job.scheduleParts("cleanup", List.of(new DropTablePart("Destroy temp table (staging)", tempTableStaging)));
+            job.scheduleParts("cleanup", List.of(new DropTablePart("Destroy temp table (final)", tempTableFinal)));
+          }
+
+          return job;
+        }
+      )
+    );
+  }
+
+  private static class CorrelateNamesAndCodesPart extends JobPart {
+
+    private final Table<?> table;
+
+    private final Field<String> key;
+    private final Field<String> reference;
+    private final Field<String> newValue;
+
+    public CorrelateNamesAndCodesPart(
+      Table<?> table,
+      Field<String> key,
+      Field<String> reference,
+      Field<String> newValue
+    ) {
+      super("Correlate names and codes");
+      this.table = table;
+      this.key = key;
+      this.reference = reference;
+      this.newValue = newValue;
+    }
+
+    @Override
+    protected void execute() {
+      this.create()
+        .update(table.as("r"))
+        .set(
+          newValue,
+          field(
+            "concat(%s, {0}, %s)".formatted(
+                RandomValueUtils.randomArrayEntrySql("", "Corp ", "Company ", "The Best "),
+                RandomValueUtils.randomArrayEntrySql(" Org", " & Family", " & Co.", ", LLC", ", Inc.", ".com")
+              ),
+            String.class,
+            field(name("c", newValue.getName()), String.class)
+          )
+        )
+        .from(table.as("c"))
+        .where(field(name("c", key.getName())).eq(field(name("r", reference.getName()))))
+        .execute();
+    }
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
@@ -21,7 +21,7 @@ import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationJobPart;
 import org.folio.anonymization.jobs.templates.CreateTablePart;
 import org.folio.anonymization.jobs.templates.DropTablePart;
-import org.folio.anonymization.jobs.templates.GenerateUniqueValuesPart;
+import org.folio.anonymization.jobs.templates.GenerateValuesPart;
 import org.folio.anonymization.jobs.templates.InsertIntoTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
 import org.folio.anonymization.util.DBUtils;
@@ -196,7 +196,7 @@ public class VendorNamesAndCodeAnonymization implements JobFactory {
                   BATCH_SIZE,
                   "generate-new-values-regular",
                   (cond, start, end) ->
-                    new GenerateUniqueValuesPart(
+                    new GenerateValuesPart(
                       "Generate values (%s-%s)".formatted(start, end),
                       tempTableFinal,
                       newValue,

--- a/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationJobPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationJobPart.java
@@ -1,0 +1,69 @@
+package org.folio.anonymization.jobs.templates;
+
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.function.TriFunction;
+import org.folio.anonymization.domain.job.JobPart;
+import org.folio.anonymization.util.DBUtils;
+import org.jooq.Condition;
+import org.jooq.Field;
+import org.jooq.Table;
+
+/**
+ * Job part to create a series of batch processing children, each acting on a range of a table.
+ *
+ * The max value for the batch will come from the table's {@link sequence DBUtils#getSequence}.
+ * Note that, in the case of row INSERT conflicts, this value may be higher than the true number
+ * of rows.
+ */
+@Log4j2
+public class BatchGenerationJobPart extends JobPart {
+
+  private final Table<?> table;
+  private final int batchSize;
+  private final String childrenJobStage;
+  private final BatchPartFactory factory;
+
+  public BatchGenerationJobPart(
+    String label,
+    Table<?> table,
+    int batchSize,
+    String childrenJobStage,
+    BatchPartFactory factory
+  ) {
+    super(label);
+    this.table = table;
+    this.batchSize = batchSize;
+    this.childrenJobStage = childrenJobStage;
+    this.factory = factory;
+  }
+
+  @Override
+  protected void execute() {
+    int totalMaxExclusive = this.create().select(DBUtils.getSequence(table).nextval()).fetchOne().value1();
+    log.info("Next value from sequence: {}", totalMaxExclusive);
+
+    Field<Integer> sequenceField = DBUtils.getSequenceField(table);
+    for (int minInclusive = 0; minInclusive < totalMaxExclusive; minInclusive += batchSize) {
+      int maxExclusive = minInclusive + batchSize;
+      this.job.scheduleParts(
+          childrenJobStage,
+          List.of(
+            factory.apply(
+              sequenceField.greaterOrEqual(minInclusive).and(sequenceField.lessThan(maxExclusive)),
+              minInclusive,
+              Math.min(maxExclusive - 1, totalMaxExclusive - 1)
+            )
+          )
+        );
+    }
+  }
+
+  /**
+   * Factory for creating parts based on a batch range. Given a jOOQ condition to match the range and an
+   * integer to start with (based on the range). It is guaranteed that this value on the range of
+   * [value, value + count(condition)) is exclusive to this part and can be used as the basis for unique
+   * values. The second value is the maximum for convenience, equal to min(value + batch_size, total)
+   */
+  public static interface BatchPartFactory extends TriFunction<Condition, Integer, Integer, JobPart> {}
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/CreateTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/CreateTablePart.java
@@ -1,0 +1,67 @@
+package org.folio.anonymization.jobs.templates;
+
+import static org.jooq.impl.DSL.field;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.anonymization.domain.job.JobPart;
+import org.folio.anonymization.util.DBUtils;
+import org.jooq.Constraint;
+import org.jooq.Field;
+import org.jooq.Sequence;
+import org.jooq.Table;
+import org.jooq.impl.SQLDataType;
+
+/**
+ * Job part to create a table. Note the following caveats:
+ * - This table MUST be manually destroyed later
+ * - This table MUST have a primary key specified
+ * - This table SHOULD have a tenant name prepended, if applicable
+ * - If a table with this name already exists, this part will drop and replace it
+ * - If a sequence is requested, a column _seq will be added at the end of the list that is an integer incrementing from 0,
+ *     and a corresponding {table}_seq sequence will be created
+ */
+public class CreateTablePart extends JobPart {
+
+  private final Table<?> table;
+  private final List<Field<?>> fields;
+  private final List<Constraint> constraints;
+  private final boolean includeSequence;
+
+  public CreateTablePart(
+    String label,
+    Table<?> table,
+    List<Field<?>> fields,
+    List<Constraint> constraints,
+    boolean includeSequence
+  ) {
+    super(label);
+    this.table = table;
+    this.fields = new ArrayList<>(fields);
+    this.constraints = constraints;
+    this.includeSequence = includeSequence;
+  }
+
+  @Override
+  protected void execute() {
+    Sequence<Integer> sequence = DBUtils.getSequence(table);
+
+    this.create().dropTableIfExists(table).cascade().execute();
+
+    if (includeSequence) {
+      this.create().dropSequenceIfExists(sequence).execute();
+      this.create().createSequence(sequence).startWith(0).minvalue(0).execute();
+    }
+
+    this.create()
+      .createTable(table)
+      .columns(fields)
+      .columns(
+        includeSequence
+          ? new Field[] { field("_seq", SQLDataType.INTEGER.notNull().defaultValue(sequence.nextval())) }
+          : new Field[] {}
+      )
+      .constraints(constraints)
+      .execute();
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/DropTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/DropTablePart.java
@@ -1,0 +1,28 @@
+package org.folio.anonymization.jobs.templates;
+
+import org.folio.anonymization.domain.job.JobPart;
+import org.folio.anonymization.util.DBUtils;
+import org.jooq.Table;
+
+/**
+ * Job part to drop a table. Note the following caveats:
+ * - This table MUST exist. The job will fail otherwise.
+ * - This table will be dropped from the `public` schema and SHOULD have a tenant name prepended, if applicable.
+ * - Child sequences (as created by CreateTablePart) will also be dropped
+ * - DROP will be executed with CASCADE
+ */
+public class DropTablePart extends JobPart {
+
+  private final Table<?> table;
+
+  public DropTablePart(String label, Table<?> table) {
+    super(label);
+    this.table = table;
+  }
+
+  @Override
+  protected void execute() {
+    this.create().dropTable(table).cascade().execute();
+    this.create().dropSequenceIfExists(DBUtils.getSequence(table)).execute();
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/GenerateUniqueValuesPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/GenerateUniqueValuesPart.java
@@ -1,0 +1,71 @@
+package org.folio.anonymization.jobs.templates;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.extern.log4j.Log4j2;
+import org.folio.anonymization.domain.job.JobPart;
+import org.jooq.Field;
+import org.jooq.Query;
+import org.jooq.Result;
+import org.jooq.Select;
+import org.jooq.Table;
+
+/**
+ * Job part to create unique data for a field in a table. Designed to be used with temporary tables,
+ * so we use a regular jOOQ Field
+ */
+@Log4j2
+public class GenerateUniqueValuesPart extends JobPart {
+
+  private static final int INSERT_BATCH_SIZE = 100;
+
+  private final Table<?> destinationTable;
+  private final Field<String> destinationField;
+  private final Select<?> source;
+  private final Function<Integer, List<String>> valueFactory;
+
+  public GenerateUniqueValuesPart(
+    String label,
+    Table<?> destinationTable,
+    Field<String> destinationField,
+    Select<?> source,
+    Function<Integer, List<String>> valueFactory
+  ) {
+    super(label);
+    this.destinationTable = destinationTable;
+    this.destinationField = destinationField;
+    this.source = source;
+    this.valueFactory = valueFactory;
+  }
+
+  @Override
+  protected void execute() {
+    Result<?> toCopy = this.create().selectFrom(source).fetch();
+
+    List<String> newValues = valueFactory.apply(toCopy.size());
+    log.info("Found {} records to copy with new values", toCopy.size());
+
+    List<Field<?>> sourceFields = Arrays.asList(source.fields());
+
+    List<Query> queries = IntStream
+      .range(0, toCopy.size())
+      .mapToObj(i ->
+        this.create()
+          .insertInto(destinationTable, Stream.concat(sourceFields.stream(), Stream.of(destinationField)).toList())
+          .values(
+            Stream.concat(sourceFields.stream().map(f -> toCopy.get(i).get(f)), Stream.of(newValues.get(i))).toList()
+          )
+      )
+      .map(Query.class::cast)
+      .toList();
+
+    for (int i = 0; i < queries.size(); i += INSERT_BATCH_SIZE) {
+      int end = Math.min(i + INSERT_BATCH_SIZE, queries.size());
+      List<Query> batch = queries.subList(i, end);
+      this.create().batch(batch).execute();
+    }
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/GenerateValuesPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/GenerateValuesPart.java
@@ -14,11 +14,12 @@ import org.jooq.Select;
 import org.jooq.Table;
 
 /**
- * Job part to create unique data for a field in a table. Designed to be used with temporary tables,
- * so we use a regular jOOQ Field
+ * Job part to create data for a field in a table. Designed to be used with temporary tables,
+ * and to copy data from one place into a new one. Columns in the destination must
+ * be the same columns as in the source, + destinationField for the new values
  */
 @Log4j2
-public class GenerateUniqueValuesPart extends JobPart {
+public class GenerateValuesPart extends JobPart {
 
   private static final int INSERT_BATCH_SIZE = 100;
 
@@ -27,7 +28,7 @@ public class GenerateUniqueValuesPart extends JobPart {
   private final Select<?> source;
   private final Function<Integer, List<String>> valueFactory;
 
-  public GenerateUniqueValuesPart(
+  public GenerateValuesPart(
     String label,
     Table<?> destinationTable,
     Field<String> destinationField,

--- a/src/main/java/org/folio/anonymization/jobs/templates/InsertIntoTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/InsertIntoTablePart.java
@@ -1,0 +1,49 @@
+package org.folio.anonymization.jobs.templates;
+
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.table;
+import static org.jooq.impl.DSL.using;
+
+import org.folio.anonymization.domain.job.JobPart;
+import org.jooq.DSLContext;
+import org.jooq.Select;
+import org.jooq.Table;
+
+/**
+ * Job part to insert data into a table. Note the following caveats:
+ * - This table for insertion MUST be present in the `public` schema and
+ *   SHOULD have a tenant name prepended, if applicable
+ * - Insertion order will be based on the destination table column definitions
+ *   and mapped 1:1 with the provided fields.
+ * - Conflicts will be handled with the 'DO NOTHING' strategy.
+ */
+public class InsertIntoTablePart extends JobPart {
+
+  private final Table<?> destinationTable;
+  private final Select<?> source;
+
+  public InsertIntoTablePart(String label, Table<?> destinationTable, Select<?> source) {
+    super(label);
+    this.destinationTable = destinationTable;
+    this.source = source;
+  }
+
+  @Override
+  protected void execute() {
+    // this mess creates a transaction which creates a temporary table, loads the data into it,
+    // then finally loads the data into the actual destinationTable with an EXCLUSIVE lock.
+    // this prevents deadlocks where multiple JobParts are inserting with conflicting primary keys,
+    // and the temporary table keeps things a little more efficient.
+    this.create()
+      .transaction(configuration -> {
+        DSLContext ctx = using(configuration);
+
+        Table<?> tempTable = table(name("staging_" + System.nanoTime()));
+
+        ctx.createTemporaryTable(tempTable).as(source).onCommitDrop().execute();
+
+        ctx.execute("LOCK TABLE {0} IN EXCLUSIVE MODE", destinationTable);
+        ctx.insertInto(destinationTable).select(ctx.selectFrom(tempTable)).onConflictDoNothing().execute();
+      });
+  }
+}


### PR DESCRIPTION
This adds a new, massive, `VendorNamesAndCodeAnonymization` which will anonymize vendor names and codes. These data types were lumped together as they often appear in the same contexts and, in some cases, our analysis was inconclusive as to whether a field was the vendor's name or code.

This was especially tricky for two reasons:
- Uniqueness and integrity must be retained. Every vendor name or code must be unique across all tables, and replacing `foo->bar` in one table should also result in the same replacement in all others.
- I wanted to keep some reference between a vendor's name and code, to make use of the resulting data a little easier. Codes are completely overwritten, then a second part goes back to update names with known correlations to something like `Company {generated code}, LLC`

This includes a few new reusable `JobPart`s:
- `CreateTablePart` will create a table (and, optionally, an auto-incrementing sequence). These are to be used for intermediate results (in this case, a list of all vendor names/codes and their anonymized version)
- `DropTablePart` will drop a table (and, optionally, its auto-incrementing sequence)
- `InsertIntoTablePart` will read data from a provided query and store it into a table
- `BatchGenerationJobPart` takes a table with an auto-incrementing sequence and spawns a number of child jobs to work over it incrementally. In this case, it was used to split the list of found vendor names/codes into small chunks (~2000)
- `GenerateValuesPart` will take data, add a random value from some source, and put it into a new table. This is designed specifically for a new table as it makes things a bit more efficient on the DB side.
