### PR TITLE
[DANON-60] Fix errors in vendor anonymization; add additional batching features

### DIFF
--- a/src/main/java/org/folio/anonymization/domain/db/FieldReference.java
+++ b/src/main/java/org/folio/anonymization/domain/db/FieldReference.java
@@ -38,6 +38,10 @@ public record FieldReference(String schema, String table, String column, String 
     return DSL.table(DSL.name(DBUtils.getSchemaName(tenant.id(), schema), table));
   }
 
+  public TableReference tableReference() {
+    return new TableReference(this.schema, this.table);
+  }
+
   public Field<Object> baseColumn(Tenant tenant) {
     return DSL.field(DSL.name(DBUtils.getSchemaName(tenant.id(), schema), table, column));
   }

--- a/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
+++ b/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
@@ -1,0 +1,49 @@
+package org.folio.anonymization.domain.db;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
+
+/**
+ * Reference of table ID columns and their types, to be used where necessary
+ * (such as {@link BatchGenerationFromTablePart})
+ */
+@UtilityClass
+public class TableIDs {
+
+  private static final List<Pair<FieldReference, Class<?>>> TABLE_ID_FIELD_LIST = List.of(
+    Pair.of(new FieldReference("agreements", "alternate_name", "an_id"), String.class),
+    Pair.of(new FieldReference("agreements", "kbart_import_job", "id"), String.class),
+    Pair.of(new FieldReference("agreements", "org", "org_id"), String.class),
+    Pair.of(new FieldReference("agreements", "package", "id"), String.class),
+    Pair.of(new FieldReference("copycat", "profile", "id"), UUID.class),
+    Pair.of(new FieldReference("erm_usage", "usage_data_providers", "id"), UUID.class),
+    Pair.of(new FieldReference("invoice_storage", "batch_vouchers", "id"), UUID.class),
+    Pair.of(new FieldReference("licenses", "alternate_name", "an_id"), String.class),
+    Pair.of(new FieldReference("licenses", "org", "org_id"), String.class),
+    Pair.of(new FieldReference("orders_storage", "export_history", "id"), UUID.class),
+    Pair.of(new FieldReference("organizations_storage", "organizations", "id"), UUID.class)
+  );
+
+  private static final Map<TableReference, Pair<FieldReference, Class<?>>> TABLE_ID_MAP;
+
+  static {
+    TABLE_ID_MAP =
+      TABLE_ID_FIELD_LIST
+        .stream()
+        .collect(Collectors.toMap(pair -> pair.getLeft().tableReference(), Function.identity()));
+  }
+
+  public static Pair<FieldReference, Class<?>> getIdFor(TableReference table) {
+    return TABLE_ID_MAP.get(table);
+  }
+
+  public static Pair<FieldReference, Class<?>> getIdFor(FieldReference field) {
+    return getIdFor(field.tableReference());
+  }
+}

--- a/src/main/java/org/folio/anonymization/domain/job/BatchPartFactory.java
+++ b/src/main/java/org/folio/anonymization/domain/job/BatchPartFactory.java
@@ -1,0 +1,14 @@
+package org.folio.anonymization.domain.job;
+
+import org.jooq.Condition;
+
+/**
+ * Factory for creating parts based on a batch range. Given a jOOQ condition to match the range and an
+ * integer to start with (based on the range). It is guaranteed that this value on the range of
+ * [value, value + count(condition)) is exclusive to this part and can be used as the basis for unique
+ * values. The end value is the maximum for convenience, equal to min(value + batch_size, total)
+ */
+@FunctionalInterface
+public interface BatchPartFactory {
+  public JobPart build(String label, Condition condition, int startIndex, int endIndex);
+}

--- a/src/main/java/org/folio/anonymization/domain/job/Job.java
+++ b/src/main/java/org/folio/anonymization/domain/job/Job.java
@@ -119,6 +119,9 @@ public final class Job {
   }
 
   public synchronized Job scheduleParts(String destinationStage, List<? extends JobPart> jobParts) {
+    if (!stages.contains(destinationStage)) {
+      throw new IllegalArgumentException("Job '%s': stage '%s' is not recognized".formatted(name, destinationStage));
+    }
     parts.computeIfAbsent(destinationStage, k -> new ConcurrentLinkedQueue<>()).addAll(jobParts);
     return this;
   }

--- a/src/main/java/org/folio/anonymization/domain/job/JobPart.java
+++ b/src/main/java/org/folio/anonymization/domain/job/JobPart.java
@@ -26,6 +26,7 @@ public abstract class JobPart implements Supplier<JobPart> {
       this.execute();
     } catch (Exception e) {
       log.error("Error executing job part: {}", label, e);
+      throw e;
     } finally {
       this.started.set(false);
       Thread.currentThread().setName("parked");

--- a/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
@@ -18,12 +18,14 @@ import org.folio.anonymization.domain.job.JobFactory;
 import org.folio.anonymization.domain.job.JobPart;
 import org.folio.anonymization.domain.job.SharedExecutionContext;
 import org.folio.anonymization.domain.job.TenantExecutionContext;
-import org.folio.anonymization.jobs.templates.BatchGenerationJobPart;
+import org.folio.anonymization.jobs.templates.BatchGenerationFromSequencePart;
+import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.CreateTablePart;
 import org.folio.anonymization.jobs.templates.DropTablePart;
 import org.folio.anonymization.jobs.templates.GenerateValuesPart;
 import org.folio.anonymization.jobs.templates.InsertIntoTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
+import org.folio.anonymization.jobs.templates.ReplaceValuePart;
 import org.folio.anonymization.util.DBUtils;
 import org.folio.anonymization.util.RandomValueUtils;
 import org.jooq.Field;
@@ -67,6 +69,7 @@ public class VendorNamesAndCodeAnonymization implements JobFactory {
   @Autowired
   private SharedExecutionContext context;
 
+  @SuppressWarnings("unchecked")
   @Override
   public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
     return List.of(
@@ -110,15 +113,17 @@ public class VendorNamesAndCodeAnonymization implements JobFactory {
             ctx,
             List.of(
               "prepare",
+              "enumerate-prep",
               // must be done discretely and as its own part since first inserts take priority
               // over later ones
               "enumerate-correlated",
               "enumerate-independent",
               // single job to count and spawn child generate-new-values jobs
               "generate-new-values-prep",
-              "generate-new-values-regular",
+              "generate-new-values",
               // overwrite generated new values for names that have codes
               "correlate-new-values",
+              "apply-new-values-prep",
               "apply-new-values",
               "cleanup"
             )
@@ -145,59 +150,75 @@ public class VendorNamesAndCodeAnonymization implements JobFactory {
               )
             );
             job.scheduleParts(
-              "enumerate-correlated",
-              JobConfigurationProperty
-                .getEnabledFields(ctx.settings())
-                .filter(pairedFields::containsKey)
-                .map(field -> {
-                  FieldReference pairedField = pairedFields.get(field);
+              "enumerate-prep",
+              Stream
+                .concat(
+                  JobConfigurationProperty
+                    .getEnabledFields(ctx.settings())
+                    .filter(pairedFields::containsKey)
+                    .map(field -> {
+                      FieldReference pairedField = pairedFields.get(field);
 
-                  return new InsertIntoTablePart(
-                    "Enumerate correlated data from " + field.toString(),
-                    tempTableStaging,
-                    select(field("a"), field("b"))
-                      .from(
-                        select(
-                          field.field(ctx.tenant().tenant(), String.class).as("a"),
-                          pairedField.field(ctx.tenant().tenant(), String.class).as("b")
-                        )
-                          .from(field.table(ctx.tenant().tenant()))
-                      )
-                      .where(field("a").isNotNull())
-                  );
-                })
-                .toList()
-            );
-            job.scheduleParts(
-              "enumerate-independent",
-              JobConfigurationProperty
-                .getEnabledFields(ctx.settings())
-                .filter(f -> !pairedFields.containsKey(f))
-                .map(field ->
-                  new InsertIntoTablePart(
-                    "Enumerate independent data from " + field.toString(),
-                    tempTableStaging,
-                    select(field("a"))
-                      .from(
-                        select(field.field(ctx.tenant().tenant(), String.class).as("a"))
-                          .from(field.table(ctx.tenant().tenant()))
-                      )
-                      .where(field("a").isNotNull())
-                  )
+                      return new BatchGenerationFromTablePart<>(
+                        "Make batches to enumerate correlated data from " + field.toString(),
+                        field,
+                        BATCH_SIZE,
+                        "enumerate-correlated",
+                        (label, condition, start, end) ->
+                          new InsertIntoTablePart(
+                            "Enumerate correlated data from " + field.toString() + " " + label,
+                            tempTableStaging,
+                            select(field("a"), field("b"))
+                              .from(
+                                select(
+                                  field.field(ctx.tenant().tenant(), String.class).as("a"),
+                                  pairedField.field(ctx.tenant().tenant(), String.class).as("b")
+                                )
+                                  .from(field.table(ctx.tenant().tenant()))
+                                  .where(condition)
+                              )
+                              .where(field("a").isNotNull())
+                          )
+                      );
+                    }),
+                  JobConfigurationProperty
+                    .getEnabledFields(ctx.settings())
+                    .filter(f -> !pairedFields.containsKey(f))
+                    .map(field -> {
+                      return new BatchGenerationFromTablePart<>(
+                        "Make batches to enumerate independent data from " + field.toString(),
+                        field,
+                        BATCH_SIZE,
+                        "enumerate-independent",
+                        (label, condition, start, end) ->
+                          new InsertIntoTablePart(
+                            "Enumerate independent data from " + field.toString() + " " + label,
+                            tempTableStaging,
+                            select(field("a"))
+                              .from(
+                                select(field.field(ctx.tenant().tenant(), String.class).as("a"))
+                                  .from(field.table(ctx.tenant().tenant()))
+                                  .where(condition)
+                              )
+                              .where(field("a").isNotNull())
+                          )
+                      );
+                    })
                 )
                 .toList()
             );
+
             job.scheduleParts(
               "generate-new-values-prep",
               List.of(
-                new BatchGenerationJobPart(
+                new BatchGenerationFromSequencePart(
                   "Analyze table size for split processing",
                   tempTableStaging,
                   BATCH_SIZE,
-                  "generate-new-values-regular",
-                  (cond, start, end) ->
+                  "generate-new-values",
+                  (label, cond, start, end) ->
                     new GenerateValuesPart(
-                      "Generate values (%s-%s)".formatted(start, end),
+                      "Generate values %s".formatted(label),
                       tempTableFinal,
                       newValue,
                       select(originalValue, referenceCode).from(tempTableStaging).where(cond),
@@ -213,19 +234,40 @@ public class VendorNamesAndCodeAnonymization implements JobFactory {
           }
 
           job.scheduleParts(
-            "apply-new-values",
+            "apply-new-values-prep",
             JobConfigurationProperty
               .getEnabledFields(ctx.settings())
               .map(field ->
-                new ReplaceJSONBValuePart(
-                  "replace",
+                new BatchGenerationFromTablePart<>(
+                  "Prep to apply new values to " + field.toString(),
                   field,
-                  innerField ->
-                    field(
-                      "to_jsonb(({0}))",
-                      JSONB.class,
-                      select(newValue).from(tempTableFinal).where(originalValue.eq(DBUtils.jsonbToString(innerField)))
-                    )
+                  BATCH_SIZE,
+                  "apply-new-values",
+                  (label, condition, start, end) -> {
+                    if (field.jsonPath() != null) {
+                      return new ReplaceJSONBValuePart(
+                        "replace %s on %s".formatted(field.toString(), label),
+                        field,
+                        innerField ->
+                          field(
+                            "to_jsonb(({0}))",
+                            JSONB.class,
+                            select(newValue)
+                              .from(tempTableFinal)
+                              .where(originalValue.eq(DBUtils.jsonbToString(innerField)))
+                          )
+                      );
+                    } else {
+                      return new ReplaceValuePart(
+                        "replace %s on %s".formatted(field.toString(), label),
+                        field,
+                        innerField ->
+                          field(
+                            select(newValue).from(tempTableFinal).where(originalValue.eq((Field<String>) innerField))
+                          )
+                      );
+                    }
+                  }
                 )
               )
               .toList()

--- a/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromSequencePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromSequencePart.java
@@ -2,10 +2,9 @@ package org.folio.anonymization.jobs.templates;
 
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.lang3.function.TriFunction;
+import org.folio.anonymization.domain.job.BatchPartFactory;
 import org.folio.anonymization.domain.job.JobPart;
 import org.folio.anonymization.util.DBUtils;
-import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Table;
 
@@ -17,14 +16,14 @@ import org.jooq.Table;
  * of rows.
  */
 @Log4j2
-public class BatchGenerationJobPart extends JobPart {
+public class BatchGenerationFromSequencePart extends JobPart {
 
   private final Table<?> table;
   private final int batchSize;
   private final String childrenJobStage;
   private final BatchPartFactory factory;
 
-  public BatchGenerationJobPart(
+  public BatchGenerationFromSequencePart(
     String label,
     Table<?> table,
     int batchSize,
@@ -49,7 +48,8 @@ public class BatchGenerationJobPart extends JobPart {
       this.job.scheduleParts(
           childrenJobStage,
           List.of(
-            factory.apply(
+            factory.build(
+              "(%s to %s)".formatted(minInclusive, Math.min(maxExclusive - 1, totalMaxExclusive - 1)),
               sequenceField.greaterOrEqual(minInclusive).and(sequenceField.lessThan(maxExclusive)),
               minInclusive,
               Math.min(maxExclusive - 1, totalMaxExclusive - 1)
@@ -58,12 +58,4 @@ public class BatchGenerationJobPart extends JobPart {
         );
     }
   }
-
-  /**
-   * Factory for creating parts based on a batch range. Given a jOOQ condition to match the range and an
-   * integer to start with (based on the range). It is guaranteed that this value on the range of
-   * [value, value + count(condition)) is exclusive to this part and can be used as the basis for unique
-   * values. The second value is the maximum for convenience, equal to min(value + batch_size, total)
-   */
-  public static interface BatchPartFactory extends TriFunction<Condition, Integer, Integer, JobPart> {}
 }

--- a/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
@@ -1,0 +1,120 @@
+package org.folio.anonymization.jobs.templates;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.db.TableIDs;
+import org.folio.anonymization.domain.db.TableReference;
+import org.folio.anonymization.domain.job.BatchPartFactory;
+import org.folio.anonymization.domain.job.JobPart;
+import org.jooq.Condition;
+import org.jooq.Field;
+import org.jooq.Table;
+
+/**
+ * Job part to create a series of batch processing children, each acting on a range of a table.
+ *
+ * The range for the batch will come from the table's values, based on a COUNT(1) query and then
+ * successive paginated queries.
+ */
+@Log4j2
+public class BatchGenerationFromTablePart<T> extends JobPart {
+
+  private final FieldReference tableId;
+  private final Class<T> tableIdType;
+  private final int batchSize;
+  private final String childrenJobStage;
+  private final BatchPartFactory factory;
+
+  public BatchGenerationFromTablePart(
+    String label,
+    FieldReference tableId,
+    Class<T> tableIdType,
+    int batchSize,
+    String childrenJobStage,
+    BatchPartFactory factory
+  ) {
+    super(label);
+    this.tableId = tableId;
+    this.tableIdType = tableIdType;
+    this.batchSize = batchSize;
+    this.childrenJobStage = childrenJobStage;
+    this.factory = factory;
+  }
+
+  @SuppressWarnings("unchecked")
+  public BatchGenerationFromTablePart(
+    String label,
+    FieldReference otherField,
+    int batchSize,
+    String childrenJobStage,
+    BatchPartFactory factory
+  ) {
+    this(
+      label,
+      TableIDs.getIdFor(otherField).getLeft(),
+      (Class<T>) TableIDs.getIdFor(otherField).getRight(),
+      batchSize,
+      childrenJobStage,
+      factory
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  public BatchGenerationFromTablePart(
+    String label,
+    TableReference table,
+    int batchSize,
+    String childrenJobStage,
+    BatchPartFactory factory
+  ) {
+    this(
+      label,
+      TableIDs.getIdFor(table).getLeft(),
+      (Class<T>) TableIDs.getIdFor(table).getRight(),
+      batchSize,
+      childrenJobStage,
+      factory
+    );
+  }
+
+  @Override
+  protected void execute() {
+    Table<?> table = tableId.table(this.tenant());
+    int totalCount = this.create().fetchCount(table);
+    log.info("Total count: {}", totalCount);
+
+    Field<T> field = this.tableId.field(this.tenant(), this.tableIdType);
+
+    // get the value of every batchSize'th element in the table
+    List<T> values = new ArrayList<>();
+
+    for (int offset = 0; offset < totalCount; offset += batchSize) {
+      values.add(this.create().select(field).from(table).orderBy(field).limit(1).offset(offset).fetchOne(field));
+    }
+
+    for (int i = 0; i < values.size(); i++) {
+      T startValueInclusive = values.get(i);
+      String prettyEndValue = "end";
+      Condition condition = field.greaterOrEqual(startValueInclusive);
+      if (i + 1 < values.size()) {
+        T endValueExclusive = values.get(i + 1);
+        prettyEndValue = endValueExclusive.toString();
+        condition = condition.and(field.lessThan(endValueExclusive));
+      }
+
+      this.job.scheduleParts(
+          childrenJobStage,
+          List.of(
+            factory.build(
+              "(%s to %s)".formatted(i == 0 ? "start" : startValueInclusive.toString(), prettyEndValue),
+              condition,
+              i * batchSize,
+              Math.min((i + 1) * batchSize, totalCount)
+            )
+          )
+        );
+    }
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/GenerateValuesPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/GenerateValuesPart.java
@@ -47,7 +47,6 @@ public class GenerateValuesPart extends JobPart {
     Result<?> toCopy = this.create().selectFrom(source).fetch();
 
     List<String> newValues = valueFactory.apply(toCopy.size());
-    log.info("Found {} records to copy with new values", toCopy.size());
 
     List<Field<?>> sourceFields = Arrays.asList(source.fields());
 

--- a/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValuePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValuePart.java
@@ -1,0 +1,57 @@
+package org.folio.anonymization.jobs.templates;
+
+import static org.jooq.impl.DSL.noCondition;
+
+import java.util.function.Function;
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.job.JobPart;
+import org.jooq.Condition;
+import org.jooq.Field;
+
+/**
+ * Job part to replace a base column with an arbitrary {@link Field Field}. Non-nested variant of
+ * {@link ReplaceJSONBValuePart}.
+ *
+ * @example
+ * new ReplaceValuePart("hardcode value", field, field("something_else", String.class))
+ */
+public class ReplaceValuePart extends JobPart {
+
+  private final FieldReference field;
+  private final Condition condition;
+
+  private final Function<Field<?>, Field<?>> replacement;
+
+  public ReplaceValuePart(String label, FieldReference field, Field<?> replacement) {
+    this(label, field, f -> replacement);
+  }
+
+  public ReplaceValuePart(String label, FieldReference field, Function<Field<?>, Field<?>> getReplacement) {
+    this(label, field, getReplacement, noCondition());
+  }
+
+  public ReplaceValuePart(
+    String label,
+    FieldReference field,
+    Function<Field<?>, Field<?>> getReplacement,
+    Condition condition
+  ) {
+    super(label + " (" + field.toString() + ")");
+    this.field = field;
+    this.replacement = getReplacement;
+    this.condition = condition;
+
+    if (field.jsonPath() != null) {
+      throw new IllegalStateException("Cannot use ReplaceValuePart on JSONB property " + field.toString());
+    }
+  }
+
+  @Override
+  protected void execute() {
+    this.create()
+      .update(field.table(this.tenant()))
+      .set(field.baseColumn(this.tenant()), replacement.apply(field.baseColumn(this.tenant())))
+      .where(this.condition)
+      .execute();
+  }
+}


### PR DESCRIPTION
This fixes a few errors:
- `JobPart`s were able to fail exceptionally but still indicated success to the parent `Job`, making errors hard to find
- This revealed that some vendor names/codes were not being updated (cases where the value was not stored in JSON)
- Batching was only being done for the generation stage, not the actual reading and updating. This has been resolved with new tooling