### PR TITLE
[DANON-56] Email replacement

### DIFF
--- a/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
+++ b/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
@@ -8,7 +8,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.Pair;
+import org.folio.anonymization.domain.folio.Tenant;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
+import org.jooq.Field;
 
 /**
  * Reference of table ID columns and their types, to be used where necessary
@@ -22,13 +24,22 @@ public class TableIDs {
     Pair.of(new FieldReference("agreements", "kbart_import_job", "id"), String.class),
     Pair.of(new FieldReference("agreements", "org", "org_id"), String.class),
     Pair.of(new FieldReference("agreements", "package", "id"), String.class),
+    Pair.of(new FieldReference("batch_print", "printing", "id"), UUID.class),
     Pair.of(new FieldReference("copycat", "profile", "id"), UUID.class),
     Pair.of(new FieldReference("erm_usage", "usage_data_providers", "id"), UUID.class),
     Pair.of(new FieldReference("invoice_storage", "batch_vouchers", "id"), UUID.class),
     Pair.of(new FieldReference("licenses", "alternate_name", "an_id"), String.class),
     Pair.of(new FieldReference("licenses", "org", "org_id"), String.class),
+    Pair.of(new FieldReference("oa", "alternate_email_address", "aea_id"), String.class),
+    Pair.of(new FieldReference("oa", "party", "p_id"), String.class),
+    Pair.of(new FieldReference("oai_pmh", "configuration_settings", "id"), UUID.class),
     Pair.of(new FieldReference("orders_storage", "export_history", "id"), UUID.class),
-    Pair.of(new FieldReference("organizations_storage", "organizations", "id"), UUID.class)
+    Pair.of(new FieldReference("organizations_storage", "contacts", "id"), UUID.class),
+    Pair.of(new FieldReference("organizations_storage", "organizations", "id"), UUID.class),
+    Pair.of(new FieldReference("organizations_storage", "privileged_contacts", "id"), UUID.class),
+    Pair.of(new FieldReference("users", "staging_users", "id"), UUID.class),
+    Pair.of(new FieldReference("users", "user_tenant", "id"), UUID.class),
+    Pair.of(new FieldReference("users", "users", "id"), UUID.class)
   );
 
   private static final Map<TableReference, Pair<FieldReference, Class<?>>> TABLE_ID_MAP;
@@ -51,5 +62,16 @@ public class TableIDs {
   @Nonnull
   public static Pair<FieldReference, Class<?>> getIdFor(FieldReference field) {
     return getIdFor(field.tableReference());
+  }
+
+  @Nonnull
+  public static Field<?> getIdFor(TableReference table, Tenant tenant) {
+    Pair<FieldReference, Class<?>> idField = getIdFor(table);
+    return idField.getLeft().field(tenant, idField.getRight());
+  }
+
+  @Nonnull
+  public static Field<?> getIdFor(FieldReference field, Tenant tenant) {
+    return getIdFor(field.tableReference(), tenant);
   }
 }

--- a/src/main/java/org/folio/anonymization/domain/job/BatchPartFactory.java
+++ b/src/main/java/org/folio/anonymization/domain/job/BatchPartFactory.java
@@ -6,7 +6,7 @@ import org.jooq.Condition;
  * Factory for creating parts based on a batch range. Given a jOOQ condition to match the range and an
  * integer to start with (based on the range). It is guaranteed that this value on the range of
  * [value, value + count(condition)) is exclusive to this part and can be used as the basis for unique
- * values. The end value is the maximum for convenience, equal to min(value + batch_size, total)
+ * values. The end value is the maximum for convenience, equal to min(value + batch_size, total).
  */
 @FunctionalInterface
 public interface BatchPartFactory {

--- a/src/main/java/org/folio/anonymization/jobs/EmailAddressAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/EmailAddressAnonymization.java
@@ -1,0 +1,80 @@
+package org.folio.anonymization.jobs;
+
+import java.util.List;
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.job.Job;
+import org.folio.anonymization.domain.job.JobBuilder;
+import org.folio.anonymization.domain.job.JobConfigurationProperty;
+import org.folio.anonymization.domain.job.JobFactory;
+import org.folio.anonymization.domain.job.SharedExecutionContext;
+import org.folio.anonymization.domain.job.TenantExecutionContext;
+import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
+import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
+import org.folio.anonymization.util.RandomValueUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailAddressAnonymization implements JobFactory {
+
+  private static final int BATCH_SIZE = 2_000;
+
+  private static final List<FieldReference> FIELDS = List.of(
+    new FieldReference("batch_print", "printing", "sorting_field"),
+    new FieldReference("erm_usage", "usage_data_providers", "jsonb", "$.sushiCredentials.requestorMail"),
+    new FieldReference("oa", "alternate_email_address", "aea_email"),
+    new FieldReference("oa", "party", "p_main_email"),
+    new FieldReference("organizations_storage", "contacts", "jsonb", "$.emails[*].value"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.contacts.emails[*].value"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.privilegedContacts.emails[*].value"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.emails[*].value"),
+    new FieldReference("organizations_storage", "organizations", "jsonb", "$.edi.ediJob.sendToEmails"),
+    new FieldReference("organizations_storage", "privileged_contacts", "jsonb", "$.emails[*].value"),
+    new FieldReference("users", "staging_users", "jsonb", "$.contactInfo.email"),
+    new FieldReference("users", "user_tenant", "email"),
+    new FieldReference("users", "users", "jsonb", "$.personal.email"),
+    // administratorEmail only exists on one row (where config_name = 'general'), however, this property
+    // only exists on that specific row, so there's no harm in including the other rows in the scope
+    // (they will simply be no-ops)
+    new FieldReference("oai_pmh", "configuration_settings", "config_value", "$.administratorEmail")
+  );
+
+  @Autowired
+  private SharedExecutionContext context;
+
+  @Override
+  public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
+    return List.of(
+      new JobBuilder(
+        "Email address anonymization",
+        "Replaces email addresses with semi-unique anonymized values",
+        tenant,
+        context,
+        JobConfigurationProperty.fromFieldList(FIELDS, tenant),
+        ctx ->
+          new Job(ctx, List.of("prepare", "overwrite"))
+            .scheduleParts(
+              "prepare",
+              JobConfigurationProperty
+                .getEnabledFields(ctx.settings())
+                .map(field ->
+                  new BatchGenerationFromTablePart<>(
+                    "Prep to apply new values to " + field.toString(),
+                    field,
+                    BATCH_SIZE,
+                    "overwrite",
+                    (label, condition, start, end) ->
+                      new ReplaceValueFromListPart(
+                        "replace %s on %s".formatted(field.toString(), label),
+                        field,
+                        condition,
+                        RandomValueUtils.emails(Math.max(end - start, 5))
+                      )
+                  )
+                )
+                .toList()
+            )
+      )
+    );
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/VendorNamesAndCodeAnonymization.java
@@ -38,7 +38,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class VendorNamesAndCodeAnonymization implements JobFactory {
 
-  // used for generating new names/codes
   private static final int BATCH_SIZE = 2_000;
 
   private static final List<FieldReference> FIELDS = List.of(

--- a/src/main/java/org/folio/anonymization/jobs/templates/CreateTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/CreateTablePart.java
@@ -1,7 +1,5 @@
 package org.folio.anonymization.jobs.templates;
 
-import static org.jooq.impl.DSL.field;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.folio.anonymization.domain.job.JobPart;
@@ -10,7 +8,6 @@ import org.jooq.Constraint;
 import org.jooq.Field;
 import org.jooq.Sequence;
 import org.jooq.Table;
-import org.jooq.impl.SQLDataType;
 
 /**
  * Job part to create a table. Note the following caveats:
@@ -56,11 +53,7 @@ public class CreateTablePart extends JobPart {
     this.create()
       .createTable(table)
       .columns(fields)
-      .columns(
-        includeSequence
-          ? new Field[] { field("_seq", SQLDataType.INTEGER.notNull().defaultValue(sequence.nextval())) }
-          : new Field[] {}
-      )
+      .columns(includeSequence ? new Field[] { DBUtils.getSequenceField(table) } : new Field[] {})
       .constraints(constraints)
       .execute();
   }

--- a/src/main/java/org/folio/anonymization/jobs/templates/InsertIntoTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/InsertIntoTablePart.java
@@ -38,7 +38,7 @@ public class InsertIntoTablePart extends JobPart {
       .transaction(configuration -> {
         DSLContext ctx = using(configuration);
 
-        Table<?> tempTable = table(name("staging_" + System.nanoTime()));
+        Table<?> tempTable = table(name("_danon_staging_" + System.nanoTime()));
 
         ctx.createTemporaryTable(tempTable).as(source).onCommitDrop().execute();
 

--- a/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValueFromListPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValueFromListPart.java
@@ -50,6 +50,10 @@ public class ReplaceValueFromListPart extends JobPart {
     this.field = field;
     this.condition = condition;
     this.replacements = replacements;
+
+    if (replacements.isEmpty()) {
+      throw new IllegalArgumentException("I can't replace values with nothing!");
+    }
   }
 
   @Override
@@ -63,7 +67,7 @@ public class ReplaceValueFromListPart extends JobPart {
         Table<?> tempTable2RefOnly = table(name("_danon_insertions_" + System.nanoTime()));
 
         Sequence<Integer> replacementsSequence = DBUtils.getSequence(tempTable);
-        this.create().createSequence(replacementsSequence).startWith(0).minvalue(0).execute();
+        ctx.createSequence(replacementsSequence).startWith(0).minvalue(0).execute();
 
         Field<Integer> replacementsSequenceField = DBUtils.getSequenceField(tempTable);
         Field<String> valueField = field("value", String.class);
@@ -85,14 +89,14 @@ public class ReplaceValueFromListPart extends JobPart {
         for (int i = 0; i < queries.size(); i += INSERT_BATCH_SIZE) {
           int end = Math.min(i + INSERT_BATCH_SIZE, queries.size());
           List<Query> batch = queries.subList(i, end);
-          this.create().batch(batch).execute();
+          ctx.batch(batch).execute();
         }
 
         // we know all values will be in our table with indexes [0,max)
-        int maxSequenceValueExclusive = this.create().select(replacementsSequence.nextval()).fetchOne().value1();
+        int maxSequenceValueExclusive = ctx.select(replacementsSequence.nextval()).fetchOne().value1();
 
         Sequence<Integer> insertionSequence = DBUtils.getSequence(tempTable2RefOnly);
-        this.create()
+        ctx
           .createSequence(insertionSequence)
           .startWith(0)
           .minvalue(0)

--- a/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValueFromListPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValueFromListPart.java
@@ -1,0 +1,138 @@
+package org.folio.anonymization.jobs.templates;
+
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.select;
+import static org.jooq.impl.DSL.table;
+import static org.jooq.impl.DSL.using;
+
+import java.util.List;
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.db.TableIDs;
+import org.folio.anonymization.domain.job.JobPart;
+import org.folio.anonymization.util.DBUtils;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.JSONB;
+import org.jooq.Query;
+import org.jooq.Record1;
+import org.jooq.Select;
+import org.jooq.Sequence;
+import org.jooq.Table;
+
+/**
+ * Job part to replace a base column with a value from a dynamically generated set.
+ * An external source will be called to generate the values used for insertion.
+ *
+ * This performs the following steps in a transaction, to keep everything in SQL and efficient as possible
+ * while still supporting nested JSONB:
+ * - Create a temporary table to hold the `replacements` and a unique sequence value
+ * - Insert all replacements into this table
+ * - Update the target table with the values from the replacements table using a second sequence
+ * - Drop the temporary table and sequences
+ *
+ * Note:
+ * - This does not guarantee that each insertion will present a unique value (nested arrays may cause replacements > values)
+ * - This does not guarantee that each generated value will end up in the final result (not applicable rows may cause replacements < values)
+ */
+public class ReplaceValueFromListPart extends JobPart {
+
+  private static final int INSERT_BATCH_SIZE = 100;
+
+  private final FieldReference field;
+  private final Condition condition;
+
+  private final List<String> replacements;
+
+  public ReplaceValueFromListPart(String label, FieldReference field, Condition condition, List<String> replacements) {
+    super(label);
+    this.field = field;
+    this.condition = condition;
+    this.replacements = replacements;
+  }
+
+  @Override
+  protected void execute() {
+    this.create()
+      .transaction(configuration -> {
+        DSLContext ctx = using(configuration);
+
+        Table<?> tempTable = table(name("_danon_replacements_" + System.nanoTime()));
+        // used only for reference to get a unique sequence name, no table of this actually exists
+        Table<?> tempTable2RefOnly = table(name("_danon_insertions_" + System.nanoTime()));
+
+        Sequence<Integer> replacementsSequence = DBUtils.getSequence(tempTable);
+        this.create().createSequence(replacementsSequence).startWith(0).minvalue(0).execute();
+
+        Field<Integer> replacementsSequenceField = DBUtils.getSequenceField(tempTable);
+        Field<String> valueField = field("value", String.class);
+
+        ctx
+          .createTemporaryTable(tempTable)
+          .columns(replacementsSequenceField, valueField)
+          .primaryKey(replacementsSequenceField)
+          .onCommitDrop()
+          .execute();
+
+        // populate new temporary table
+        List<Query> queries = replacements
+          .stream()
+          .map(value -> ctx.insertInto(tempTable).columns(valueField).values(value))
+          .map(Query.class::cast)
+          .toList();
+
+        for (int i = 0; i < queries.size(); i += INSERT_BATCH_SIZE) {
+          int end = Math.min(i + INSERT_BATCH_SIZE, queries.size());
+          List<Query> batch = queries.subList(i, end);
+          this.create().batch(batch).execute();
+        }
+
+        // we know all values will be in our table with indexes [0,max)
+        int maxSequenceValueExclusive = this.create().select(replacementsSequence.nextval()).fetchOne().value1();
+
+        Sequence<Integer> insertionSequence = DBUtils.getSequence(tempTable2RefOnly);
+        this.create()
+          .createSequence(insertionSequence)
+          .startWith(0)
+          .minvalue(0)
+          .maxvalue(maxSequenceValueExclusive - 1)
+          .cycle()
+          .execute();
+
+        Select<? extends Record1<?>> select = select(valueField)
+          // must query the next value from the insertion sequence in the from clause
+          // to ensure it only runs once per subquery execution
+          .from(tempTable, select(insertionSequence.nextval().as("chosen_seq")))
+          .where(
+            replacementsSequenceField
+              .eq(field("chosen_seq", Integer.class))
+              // we must bind to the outer column in some way or this will not be re-executed for each update
+              // (thanks postgres for cleverly optimizing! 🙃)
+              .and(TableIDs.getIdFor(field, this.tenant()).isNotNull())
+          );
+
+        // do the actual update
+        if (field.jsonPath() == null) {
+          ctx
+            .update(field.table(this.tenant()))
+            .set(field.baseColumn(this.tenant()), select)
+            .where(field.baseColumn(this.tenant()).isNotNull().and(this.condition))
+            .execute();
+        } else {
+          ctx
+            .update(field.table(this.tenant()))
+            .set(
+              field.baseColumn(this.tenant()),
+              field.jsonbSet(this.tenant(), i -> field("to_jsonb(({0}))", JSONB.class, select))
+            )
+            .where(this.condition)
+            .execute();
+        }
+
+        ctx.dropTemporaryTable(tempTable).cascade().execute();
+        ctx.dropSequence(replacementsSequence).execute();
+        ctx.dropSequence(insertionSequence).execute();
+      });
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValuePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValuePart.java
@@ -51,7 +51,7 @@ public class ReplaceValuePart extends JobPart {
     this.create()
       .update(field.table(this.tenant()))
       .set(field.baseColumn(this.tenant()), replacement.apply(field.baseColumn(this.tenant())))
-      .where(this.condition)
+      .where(field.baseColumn(this.tenant()).isNotNull().and(this.condition))
       .execute();
   }
 }

--- a/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
+++ b/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
@@ -15,7 +15,7 @@ public class RandomValueUtils {
 
   // defining static ones instead of allowing Faker to fill this in as our anonymized system may
   // attempt to send emails and we want to ensure we don't accidentally hit a real inbox.
-  private static final List<String> emailDomains = List.of(
+  private static final List<String> EMAIL_DOMAINS = List.of(
     "@example.com",
     "@library.example.com",
     "@institution.example.com",
@@ -50,7 +50,7 @@ public class RandomValueUtils {
   public static List<String> emails(int qty) {
     return IntStream
       .range(0, qty)
-      .mapToObj(i -> FAKER.name().username() + emailDomains.get(FAKER.random().nextInt(emailDomains.size())))
+      .mapToObj(i -> FAKER.name().username() + EMAIL_DOMAINS.get(FAKER.random().nextInt(EMAIL_DOMAINS.size())))
       .toList();
   }
 }

--- a/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
+++ b/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
@@ -13,6 +13,15 @@ import org.apache.commons.lang3.StringUtils;
 @UtilityClass
 public class RandomValueUtils {
 
+  // defining static ones instead of allowing Faker to fill this in as our anonymized system may
+  // attempt to send emails and we want to ensure we don't accidentally hit a real inbox.
+  private static final List<String> emailDomains = List.of(
+    "@example.com",
+    "@library.example.com",
+    "@institution.example.com",
+    "@folio.example.org"
+  );
+
   private static final Faker FAKER = new Faker();
   private static final Base64.Encoder B64 = Base64.getEncoder();
   private static final Base64.Encoder B64_NO_PADDING = B64.withoutPadding();
@@ -36,5 +45,12 @@ public class RandomValueUtils {
 
   public static String randomArrayEntryToJsonbSql(String... options) {
     return "to_jsonb(%s)".formatted(randomArrayEntrySql(options));
+  }
+
+  public static List<String> emails(int qty) {
+    return IntStream
+      .range(0, qty)
+      .mapToObj(i -> FAKER.name().username() + emailDomains.get(FAKER.random().nextInt(emailDomains.size())))
+      .toList();
   }
 }


### PR DESCRIPTION
Adds a `ReplaceValueFromListPart` which is smart enough to create a temp table on the fly based on a list of dynamically created values, perfect for emails and other similar values which cannot easily be generated in SQL alone, and have unpredictable quantities.