### PR TITLE
Allow multiple fields to be used in ReplaceValueFromListPart

### DIFF
--- a/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValueFromListPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ReplaceValueFromListPart.java
@@ -6,10 +6,15 @@ import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.table;
 import static org.jooq.impl.DSL.using;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 import lombok.Getter;
 import org.folio.anonymization.domain.db.FieldReference;
 import org.folio.anonymization.domain.db.TableIDs;
+import org.folio.anonymization.domain.db.TableReference;
 import org.folio.anonymization.domain.job.JobPart;
 import org.folio.anonymization.util.DBUtils;
 import org.jooq.Condition;
@@ -17,7 +22,7 @@ import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.JSONB;
 import org.jooq.Query;
-import org.jooq.Record1;
+import org.jooq.Record;
 import org.jooq.Select;
 import org.jooq.Sequence;
 import org.jooq.Table;
@@ -41,20 +46,51 @@ public class ReplaceValueFromListPart extends JobPart {
 
   private static final int INSERT_BATCH_SIZE = 100;
 
-  private final FieldReference field;
+  private final List<FieldReference> fields;
   private final Condition condition;
 
   @Getter // for testing
-  private final List<String> replacements;
+  private final List<List<?>> replacements;
+
+  private List<Field<?>> valueFields;
 
   public ReplaceValueFromListPart(String label, FieldReference field, Condition condition, List<String> replacements) {
+    this(label, List.of(field), condition, List.of(replacements), List.of(field("value", String.class)));
+  }
+
+  /**
+   * Replace multiple values at once. {@code fields}, {@code replacements}, and {@code replacementFields} must have the same size.
+   *
+   * @param label job label
+   * @param fields list of fields to replace
+   * @param condition condition to use (for batching)
+   * @param replacements list of replacement values
+   * @param valueFields list of temporary fields to use for replacements (eg {@code field("value", String.class)})
+   */
+  public ReplaceValueFromListPart(
+    String label,
+    List<FieldReference> fields,
+    Condition condition,
+    List<List<?>> replacements,
+    List<Field<?>> valueFields
+  ) {
     super(label);
-    this.field = field;
+    this.fields = fields;
     this.condition = condition;
     this.replacements = replacements;
+    this.valueFields = valueFields;
 
-    if (replacements.isEmpty()) {
+    if (replacements.stream().anyMatch(List::isEmpty)) {
       throw new IllegalArgumentException("I can't replace values with nothing!");
+    }
+
+    if (fields.size() != replacements.size() || fields.size() != valueFields.size()) {
+      throw new IllegalArgumentException("Fields, replacements, and valueFields must have the same size!");
+    }
+
+    TableReference table = fields.get(0).tableReference();
+    if (fields.stream().anyMatch(f -> !f.tableReference().equals(table))) {
+      throw new IllegalArgumentException("All fields must be from the same table!");
     }
   }
 
@@ -72,11 +108,10 @@ public class ReplaceValueFromListPart extends JobPart {
         ctx.createSequence(replacementsSequence).startWith(0).minvalue(0).execute();
 
         Field<Integer> replacementsSequenceField = DBUtils.getSequenceField(tempTable);
-        Field<String> valueField = field("value", String.class);
 
         ctx
           .createTemporaryTable(tempTable)
-          .columns(replacementsSequenceField, valueField)
+          .columns(Stream.concat(Stream.of(replacementsSequenceField), valueFields.stream()).toList())
           .primaryKey(replacementsSequenceField)
           .onCommitDrop()
           .execute();
@@ -84,7 +119,7 @@ public class ReplaceValueFromListPart extends JobPart {
         // populate new temporary table
         List<Query> queries = replacements
           .stream()
-          .map(value -> ctx.insertInto(tempTable).columns(valueField).values(value))
+          .map(value -> ctx.insertInto(tempTable).columns(valueFields).values(value))
           .map(Query.class::cast)
           .toList();
 
@@ -94,52 +129,56 @@ public class ReplaceValueFromListPart extends JobPart {
           ctx.batch(batch).execute();
         }
 
-        int replacementCount = replacements.size();
-
-        Select<? extends Record1<?>> select;
         Sequence<Integer> insertionSequence = DBUtils.getSequence(tempTable2RefOnly);
-        if (replacementCount == 1) {
-          // Avoid creating a sequence with MINVALUE == MAXVALUE, which Postgres rejects.
-          select = select(valueField).from(tempTable).limit(1);
-        } else {
-          ctx
-            .createSequence(insertionSequence)
-            .startWith(0)
-            .minvalue(0)
-            .maxvalue(replacementCount - 1)
-            .cycle()
-            .execute();
+        List<Select<? extends Record>> selects = new ArrayList<>(fields.size());
+        for (int i = 0; i < fields.size(); i++) {
+          int replacementCount = replacements.get(i).size();
+          if (replacementCount == 1) {
+            // Avoid creating a sequence with MINVALUE == MAXVALUE, which Postgres rejects.
+            selects.add(select(valueFields.get(i)).from(tempTable).limit(1));
+          } else {
+            ctx
+              .createSequence(insertionSequence)
+              .startWith(0)
+              .minvalue(0)
+              .maxvalue(replacementCount - 1)
+              .cycle()
+              .execute();
 
-          select =
-            select(valueField)
-              // must query the next value from the insertion sequence in the from clause
-              // to ensure it only runs once per subquery execution
-              .from(tempTable, select(insertionSequence.nextval().as("chosen_seq")))
-              .where(
-                replacementsSequenceField
-                  .eq(field("chosen_seq", Integer.class))
-                  // we must bind to the outer column in some way or this will not be re-executed for each update
-                  // (thanks postgres for cleverly optimizing! 🙃)
-                  .and(TableIDs.getIdFor(field, this.tenant()).isNotNull())
-              );
+            selects.add(
+              select(valueFields.get(i))
+                // must query the next value from the insertion sequence in the from clause
+                // to ensure it only runs once per subquery execution
+                .from(tempTable, select(insertionSequence.nextval().as("chosen_seq")))
+                .where(
+                  replacementsSequenceField
+                    .eq(field("chosen_seq", Integer.class))
+                    // we must bind to the outer column in some way or this will not be re-executed for each update
+                    // (thanks postgres for cleverly optimizing! 🙃)
+                    .and(TableIDs.getIdFor(fields.get(i), this.tenant()).isNotNull())
+                )
+            );
+          }
         }
-        // do the actual update
-        if (field.jsonPath() == null) {
-          ctx
-            .update(field.table(this.tenant()))
-            .set(field.baseColumn(this.tenant()), select)
-            .where(field.baseColumn(this.tenant()).isNotNull().and(this.condition))
-            .execute();
-        } else {
-          ctx
-            .update(field.table(this.tenant()))
-            .set(
+
+        Map<Field<?>, Object> updateFields = new HashMap<>();
+        Condition updateCondition = this.condition;
+        for (int i = 0; i < fields.size(); i++) {
+          FieldReference field = fields.get(i);
+          Select<?> select = selects.get(i);
+          if (field.jsonPath() == null) {
+            updateFields.put(field.baseColumn(this.tenant()), select);
+            updateCondition = updateCondition.and(field.baseColumn(this.tenant()).isNotNull());
+          } else {
+            updateFields.put(
               field.baseColumn(this.tenant()),
-              field.jsonbSet(this.tenant(), i -> field("to_jsonb(({0}))", JSONB.class, select))
-            )
-            .where(this.condition)
-            .execute();
+              field.jsonbSet(this.tenant(), inner -> field("to_jsonb(({0}))", JSONB.class, select))
+            );
+          }
         }
+
+        // do the actual update
+        ctx.update(fields.get(0).table(this.tenant())).set(updateFields).where(updateCondition).execute();
 
         ctx.dropTemporaryTable(tempTable).cascade().execute();
         ctx.dropSequence(replacementsSequence).execute();

--- a/src/test/java/org/folio/anonymization/jobs/UserAgentAnonymizationTest.java
+++ b/src/test/java/org/folio/anonymization/jobs/UserAgentAnonymizationTest.java
@@ -30,7 +30,8 @@ class UserAgentAnonymizationTest {
     ReplaceValueFromListPart userAgentPart = parts.getFirst();
     assertTrue(userAgentPart.getLabel().contains("$.userAgent"));
 
-    List<String> replacements = userAgentPart.getReplacements();
+    @SuppressWarnings("unchecked")
+    List<String> replacements = (List<String>) userAgentPart.getReplacements().get(0);
     assertTrue(replacements.size() >= 10 && replacements.size() <= 20);
     assertTrue(replacements.stream().allMatch(value -> value != null && !value.isBlank()));
   }


### PR DESCRIPTION
This should support profile pictures and whatever other cases (outside of multiple JSONB updates to the same column, which still need to be processed in separate parts).

It can be used for profile pictures with something like:

```java
job.scheduleParts(
  "prepare",
  List
    .of(
      new BatchGenerationFromTablePart<>(
        "Prep to replace profile pictures",
        new TableReference("users", "profile_picture"),
        JobConfig.BATCH_SIZE,
        "overwrite",
        (label, condition, start, end) ->
          new ReplaceValueFromListPart(
            "replace profile pictures on %s".formatted(label),
            List.of(
              new FieldReference("users", "profile_picture", "profile_picture_blob"),
              new FieldReference("users", "profile_picture", "hmac")
            ),
            condition,
            List.of(/* loaded blobs and hmacs go here, each in a separate list */),
            List.of(field("new_blob", SQLDataType.BLOB.nullable(true)), field("new_hmac", SQLDataType.BLOB.nullable(true)))
          )
      )
    )
    .toList()
);
```