### PR TITLE
Redact global fields

### DIFF
--- a/src/main/java/org/folio/anonymization/domain/db/FieldReference.java
+++ b/src/main/java/org/folio/anonymization/domain/db/FieldReference.java
@@ -5,6 +5,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.text.StringSubstitutor;
 import org.folio.anonymization.domain.folio.Tenant;
@@ -22,7 +25,16 @@ import org.jooq.impl.DSL;
  * new FieldReference("users", "users", "id", null);
  * new FieldReference("users", "users", "jsonb", "$.id");
  */
-public record FieldReference(String schema, String table, String column, String jsonPath) {
+@Getter
+@AllArgsConstructor
+@Accessors(fluent = true)
+public class FieldReference {
+
+  private final String schema;
+  private final String table;
+  private final String column;
+  private final String jsonPath;
+
   public FieldReference(String schema, String table, String column) {
     this(schema, table, column, null);
   }

--- a/src/main/java/org/folio/anonymization/domain/db/GlobalFieldReference.java
+++ b/src/main/java/org/folio/anonymization/domain/db/GlobalFieldReference.java
@@ -1,0 +1,59 @@
+package org.folio.anonymization.domain.db;
+
+import java.util.function.Function;
+import lombok.With;
+import org.folio.anonymization.domain.folio.Tenant;
+import org.jooq.Field;
+import org.jooq.JSONB;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+
+/**
+ * Defines a field's location outside the regular tenant_mod_ schema format. For example:
+ *
+ * @example
+ * new GlobalFieldReference("public", "tenants", "id");
+ * new GlobalFieldReference("data_import_global", "queue_items", "id");
+ */
+@With
+public class GlobalFieldReference extends FieldReference {
+
+  public GlobalFieldReference(String schema, String table, String column) {
+    super(schema, table, column, null);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("global %s.%s.%s", this.schema(), this.table(), this.column());
+  }
+
+  @Override
+  public Table<?> table(Tenant tenant) {
+    return DSL.table(DSL.name(this.schema(), this.table()));
+  }
+
+  @Override
+  public TableReference tableReference() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Field<Object> baseColumn(Tenant tenant) {
+    return DSL.field(DSL.name(this.schema(), this.table(), this.column()));
+  }
+
+  @Override
+  public <T> Field<T> baseColumn(Tenant tenant, Class<T> clazz) {
+    return DSL.field(DSL.name(this.schema(), this.table(), this.column()), clazz);
+  }
+
+  @Override
+  public <T> Field<T> field(Tenant tenant, Class<T> clazz) {
+    return this.baseColumn(tenant, clazz);
+  }
+
+  @Override
+  public Field<JSONB> jsonbSet(Tenant tenant, Function<Field<JSONB>, Field<JSONB>> replacement) {
+    throw new UnsupportedOperationException("GlobalFieldReference does not support JSONB");
+  }
+}

--- a/src/main/java/org/folio/anonymization/domain/job/JobConfigurationProperty.java
+++ b/src/main/java/org/folio/anonymization/domain/job/JobConfigurationProperty.java
@@ -11,9 +11,10 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.Data;
 import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.db.GlobalFieldReference;
 import org.folio.anonymization.domain.db.ModuleTable;
-import org.folio.anonymization.domain.db.TableIDs;
 import org.folio.anonymization.domain.db.TableReference;
+import org.folio.anonymization.repository.UtilRepository;
 import org.folio.anonymization.util.NumberUtils;
 
 @Data
@@ -55,13 +56,30 @@ public class JobConfigurationProperty {
     List<FieldReference> fields,
     TenantExecutionContext tenantInfo
   ) {
+    return fromFieldList(fields, tenantInfo, null);
+  }
+
+  public static List<JobConfigurationProperty> fromFieldList(
+    List<? extends FieldReference> fields,
+    TenantExecutionContext tenantInfo,
+    UtilRepository utilRepository
+  ) {
     return fields
       .stream()
-      .map(f -> {
-        TableIDs.getIdFor(f);
-        return f;
-      })
       .map(field -> {
+        if (field instanceof GlobalFieldReference) {
+          if (utilRepository.doesTableExist(field.schema(), field.table())) {
+            return new JobConfigurationProperty(field, row(text(field.toString())), true, false);
+          } else {
+            return new JobConfigurationProperty(
+              field,
+              row(text(field.toString()).crossedOut(), spacer(1), text("(not available)").italic()),
+              true,
+              true
+            );
+          }
+        }
+
         Optional<ModuleTable> foundTable = tenantInfo
           .availableTables()
           .stream()

--- a/src/main/java/org/folio/anonymization/jobs/FilenameRedaction.java
+++ b/src/main/java/org/folio/anonymization/jobs/FilenameRedaction.java
@@ -3,6 +3,7 @@ package org.folio.anonymization.jobs;
 import java.util.List;
 import org.folio.anonymization.config.JobConfig;
 import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.db.GlobalFieldReference;
 import org.folio.anonymization.domain.job.Job;
 import org.folio.anonymization.domain.job.JobBuilder;
 import org.folio.anonymization.domain.job.JobConfigurationProperty;
@@ -11,6 +12,7 @@ import org.folio.anonymization.domain.job.SharedExecutionContext;
 import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.RedactPart;
+import org.folio.anonymization.repository.UtilRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class FilenameRedaction implements JobFactory {
 
   private static final List<FieldReference> FIELDS = List.of(
+    new GlobalFieldReference("data_import_global", "queue_items", "file_path"),
     new FieldReference("agreements", "file_upload", "fu_filename"),
     new FieldReference("data_export", "file_definitions", "jsonb", "$.filename"),
     new FieldReference("data_export", "file_definitions", "jsonb", "$.sourcePath"),
@@ -59,6 +62,9 @@ public class FilenameRedaction implements JobFactory {
   @Autowired
   private SharedExecutionContext context;
 
+  @Autowired
+  private UtilRepository utilRepository;
+
   @Override
   public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
     return List.of(
@@ -67,13 +73,14 @@ public class FilenameRedaction implements JobFactory {
         "Redacts filenames and S3 paths by replacing all alphanumeric characters with 'X' and '1'.",
         tenant,
         context,
-        JobConfigurationProperty.fromFieldList(FIELDS, tenant),
+        JobConfigurationProperty.fromFieldList(FIELDS, tenant, utilRepository),
         ctx ->
           new Job(ctx, List.of("prepare", "redact"))
             .scheduleParts(
               "prepare",
               JobConfigurationProperty
                 .getEnabledFields(ctx.settings())
+                .filter(field -> !(field instanceof GlobalFieldReference))
                 .map(field ->
                   new BatchGenerationFromTablePart<>(
                     "Prepare to redact " + field.toString(),
@@ -82,6 +89,24 @@ public class FilenameRedaction implements JobFactory {
                     "redact",
                     (label, condition, start, end) ->
                       new RedactPart("Redact " + field.toString() + " on " + label, field, condition)
+                  )
+                )
+                .toList()
+            )
+            // too messy to attempt to batch this table which should be minimal (ephemeral and only hold in-progress jobs)
+            .scheduleParts(
+              "redact",
+              JobConfigurationProperty
+                .getEnabledFields(ctx.settings())
+                .filter(GlobalFieldReference.class::isInstance)
+                .map(GlobalFieldReference.class::cast)
+                .map(field ->
+                  new RedactPart(
+                    "Redact " + field.toString(),
+                    field,
+                    new GlobalFieldReference("data_import_global", "queue_items", "tenant")
+                      .field(null, String.class)
+                      .eq(tenant.tenant().id())
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/TenantInfoRedaction.java
+++ b/src/main/java/org/folio/anonymization/jobs/TenantInfoRedaction.java
@@ -1,0 +1,61 @@
+package org.folio.anonymization.jobs;
+
+import java.util.List;
+import org.folio.anonymization.domain.db.GlobalFieldReference;
+import org.folio.anonymization.domain.job.Job;
+import org.folio.anonymization.domain.job.JobBuilder;
+import org.folio.anonymization.domain.job.JobConfigurationProperty;
+import org.folio.anonymization.domain.job.JobFactory;
+import org.folio.anonymization.domain.job.SharedExecutionContext;
+import org.folio.anonymization.domain.job.TenantExecutionContext;
+import org.folio.anonymization.jobs.templates.RedactPart;
+import org.folio.anonymization.repository.UtilRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TenantInfoRedaction implements JobFactory {
+
+  private static final List<GlobalFieldReference> FIELDS = List.of(
+    new GlobalFieldReference("public", "tenant_info", "created_by_username"),
+    new GlobalFieldReference("public", "tenant_info", "updated_by_username")
+  );
+
+  @Autowired
+  private SharedExecutionContext context;
+
+  @Autowired
+  private UtilRepository utilRepository;
+
+  @Override
+  public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
+    return List.of(
+      new JobBuilder(
+        "Tenant metadata redaction",
+        "Redacts information about the user who created/updated this tenant",
+        tenant,
+        context,
+        JobConfigurationProperty.fromFieldList(FIELDS, tenant, utilRepository),
+        ctx ->
+          new Job(ctx, List.of("redact"))
+            // we will only update one row so no need to batch
+            .scheduleParts(
+              "redact",
+              JobConfigurationProperty
+                .getEnabledFields(ctx.settings())
+                .map(GlobalFieldReference.class::cast)
+                .map(field ->
+                  new RedactPart(
+                    "Redact " + field.toString(),
+                    field,
+                    new GlobalFieldReference("public", "tenant_info", "tenant_id")
+                      .field(null, String.class)
+                      .eq(tenant.tenant().id())
+                  )
+                )
+                .toList()
+            )
+      )
+    );
+  }
+}

--- a/src/main/java/org/folio/anonymization/repository/UtilRepository.java
+++ b/src/main/java/org/folio/anonymization/repository/UtilRepository.java
@@ -39,6 +39,17 @@ public class UtilRepository {
     return doesSchemaExist(DBUtils.getSchemaName(tenantName, normalizedModuleName));
   }
 
+  public boolean doesTableExist(String schemaName, String tableName) {
+    return (
+      create
+        .selectOne()
+        .from(name("information_schema", "tables"))
+        .where(field("table_schema", String.class).eq(schemaName).and(field("table_name", String.class).eq(tableName)))
+        .fetchOne() !=
+      null
+    );
+  }
+
   /**
    * Get a list of table sizes in schemas starting with the given prefix. These are approximate
    * and based on the information found in pg_class, and may not be available if the table


### PR DESCRIPTION
These three fields (one filename + two usernames) require special handling since they're not in a tenant-specific schema. For this I added a new `GlobalFieldReference` with special overrides to remove the tenant qualification.

For the tenant metadata usernames, the usernames themselves don't really make sense in the context (as they cannot be associated to a specific tenant except maybe `supertenant`, which doesn't have traditional users) so we can safely just redact them. In my testing they're just `SYSTEM` anyways. This is specialized enough I didn't feel it appropriate to include as part of the `UsernameAnonymization` job.