### PR TITLE
[DANON-65] [DANON-66] [DANON-67] Custom fields

### DIFF
--- a/src/main/java/org/folio/anonymization/domain/db/FieldReference.java
+++ b/src/main/java/org/folio/anonymization/domain/db/FieldReference.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.With;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.text.StringSubstitutor;
@@ -25,6 +26,7 @@ import org.jooq.impl.DSL;
  * new FieldReference("users", "users", "id", null);
  * new FieldReference("users", "users", "jsonb", "$.id");
  */
+@With
 @Getter
 @AllArgsConstructor
 @Accessors(fluent = true)

--- a/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
+++ b/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
@@ -170,6 +170,7 @@ public class TableIDs {
     Pair.of(new FieldReference("oa", "publication_request_history", "prh_id"), String.class),
     Pair.of(new FieldReference("oa", "publication_status", "ps_id"), String.class),
     Pair.of(new FieldReference("oai_pmh", "configuration_settings", "id"), UUID.class),
+    Pair.of(new FieldReference("orders_storage", "custom_fields", "id"), UUID.class),
     Pair.of(new FieldReference("orders_storage", "export_history", "id"), UUID.class),
     Pair.of(new FieldReference("orders_storage", "pieces", "id"), UUID.class),
     Pair.of(new FieldReference("orders_storage", "po_line", "id"), UUID.class),

--- a/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
+++ b/src/main/java/org/folio/anonymization/domain/db/TableIDs.java
@@ -22,8 +22,23 @@ public class TableIDs {
   private static final List<Pair<FieldReference, Class<?>>> TABLE_ID_FIELD_LIST = List.of(
     Pair.of(new FieldReference("agreements", "agreement_relationship", "ar_id"), String.class),
     Pair.of(new FieldReference("agreements", "alternate_name", "an_id"), String.class),
+    Pair.of(new FieldReference("agreements", "comparison_job", "id"), String.class),
+    Pair.of(new FieldReference("agreements", "custom_property_blob", "id"), Integer.class),
+    Pair.of(new FieldReference("agreements", "custom_property_definition", "pd_id"), String.class),
+    Pair.of(new FieldReference("agreements", "custom_property_integer", "id"), Integer.class),
+    Pair.of(
+      new FieldReference("agreements", "custom_property_multi_integer_value", "custom_property_multi_integer_id"),
+      Integer.class
+    ),
+    Pair.of(
+      new FieldReference("agreements", "custom_property_multi_text_value", "custom_property_multi_text_id"),
+      Integer.class
+    ),
+    Pair.of(new FieldReference("agreements", "custom_property_text", "id"), Integer.class),
+    Pair.of(new FieldReference("agreements", "custom_property", "id"), Integer.class),
     Pair.of(new FieldReference("agreements", "document_attachment", "da_id"), String.class),
     Pair.of(new FieldReference("agreements", "entitlement", "ent_id"), String.class),
+    Pair.of(new FieldReference("agreements", "file_object", "fo_id"), String.class),
     Pair.of(new FieldReference("agreements", "file_upload", "fu_id"), String.class),
     Pair.of(new FieldReference("agreements", "kbart_import_job", "id"), String.class),
     Pair.of(new FieldReference("agreements", "license_amendment_status", "las_id"), String.class),
@@ -119,11 +134,26 @@ public class TableIDs {
     Pair.of(new FieldReference("kb_ebsco_java", "resources", "id"), UUID.class),
     Pair.of(new FieldReference("kb_ebsco_java", "usage_consolidation_settings", "id"), UUID.class),
     Pair.of(new FieldReference("licenses", "alternate_name", "an_id"), String.class),
+    Pair.of(new FieldReference("licenses", "custom_property", "id"), Integer.class),
+    Pair.of(new FieldReference("licenses", "custom_property_definition", "pd_id"), String.class),
+    Pair.of(new FieldReference("licenses", "custom_property_blob", "id"), Integer.class),
+    Pair.of(new FieldReference("licenses", "custom_property_integer", "id"), Integer.class),
+    Pair.of(
+      new FieldReference("licenses", "custom_property_multi_integer_value", "custom_property_multi_integer_id"),
+      Integer.class
+    ),
+    Pair.of(
+      new FieldReference("licenses", "custom_property_multi_text_value", "custom_property_multi_text_id"),
+      Integer.class
+    ),
+    Pair.of(new FieldReference("licenses", "custom_property_text", "id"), Integer.class),
     Pair.of(new FieldReference("licenses", "document_attachment", "da_id"), String.class),
+    Pair.of(new FieldReference("licenses", "file_object", "fo_id"), String.class),
     Pair.of(new FieldReference("licenses", "file_upload", "fu_id"), String.class),
     Pair.of(new FieldReference("licenses", "license_org_role", "lior_id"), String.class),
     Pair.of(new FieldReference("licenses", "license_org", "sao_id"), String.class),
     Pair.of(new FieldReference("licenses", "org", "org_id"), String.class),
+    Pair.of(new FieldReference("licenses", "refdata_value", "rdv_id"), String.class),
     Pair.of(new FieldReference("lists", "list_details", "id"), UUID.class),
     Pair.of(new FieldReference("lists", "list_refresh_details", "id"), UUID.class),
     Pair.of(new FieldReference("lists", "list_versions", "id"), UUID.class),
@@ -169,9 +199,26 @@ public class TableIDs {
     Pair.of(new FieldReference("serials_management", "enumeration_numeric_leveltmrf", "enltmrf_id"), String.class),
     Pair.of(new FieldReference("serials_management", "predicted_piece_set", "pps_id"), String.class),
     Pair.of(new FieldReference("serials_management", "serial_note", "sn_id"), String.class),
+    Pair.of(new FieldReference("service_interaction", "custom_property_definition", "pd_id"), String.class),
+    Pair.of(new FieldReference("service_interaction", "custom_property", "id"), Integer.class),
+    Pair.of(new FieldReference("service_interaction", "custom_property_blob", "id"), Integer.class),
+    Pair.of(new FieldReference("service_interaction", "custom_property_integer", "id"), Integer.class),
+    Pair.of(
+      new FieldReference("service_interaction", "custom_property_multi_text_value", "custom_property_multi_text_id"),
+      Integer.class
+    ),
+    Pair.of(new FieldReference("service_interaction", "custom_property_text", "id"), Integer.class),
     Pair.of(new FieldReference("service_interaction", "dashboard", "dshb_id"), String.class),
     Pair.of(new FieldReference("service_interaction", "refdata_value", "rdv_id"), String.class),
     Pair.of(new FieldReference("service_interaction", "widget_instance", "wins_id"), String.class),
+    Pair.of(
+      new FieldReference(
+        "service_interaction",
+        "custom_property_multi_integer_value",
+        "custom_property_multi_integer_id"
+      ),
+      Integer.class
+    ),
     Pair.of(new FieldReference("source_record_manager", "job_execution", "id"), UUID.class),
     Pair.of(new FieldReference("tags", "tags", "id"), UUID.class),
     Pair.of(new FieldReference("template_engine", "template", "id"), UUID.class),

--- a/src/main/java/org/folio/anonymization/domain/db/TableReference.java
+++ b/src/main/java/org/folio/anonymization/domain/db/TableReference.java
@@ -1,5 +1,6 @@
 package org.folio.anonymization.domain.db;
 
+import lombok.With;
 import org.folio.anonymization.domain.folio.Tenant;
 import org.folio.anonymization.util.DBUtils;
 import org.jooq.Table;
@@ -11,6 +12,7 @@ import org.jooq.impl.DSL;
  * @example
  * new TableReference("fqm_manager", "entity_type_definition");
  */
+@With
 public record TableReference(String schema, String table) {
   public String toString() {
     return String.format("%s.%s", schema, table);
@@ -18,5 +20,13 @@ public record TableReference(String schema, String table) {
 
   public Table<?> table(Tenant tenant) {
     return DSL.table(DSL.name(DBUtils.getSchemaName(tenant.id(), schema), table));
+  }
+
+  public FieldReference field(String column) {
+    return new FieldReference(schema, table, column);
+  }
+
+  public FieldReference field(String column, String jsonPath) {
+    return new FieldReference(schema, table, column, jsonPath);
   }
 }

--- a/src/main/java/org/folio/anonymization/domain/job/JobConfigurationProperty.java
+++ b/src/main/java/org/folio/anonymization/domain/job/JobConfigurationProperty.java
@@ -92,7 +92,7 @@ public class JobConfigurationProperty {
           return new JobConfigurationProperty(
             field,
             row(
-              text("mod_"),
+              text("mod_").crossedOut(),
               text(field.toString()).crossedOut(),
               spacer(1),
               text("(not available for tenant)").italic()
@@ -134,7 +134,7 @@ public class JobConfigurationProperty {
           return new JobConfigurationProperty(
             table,
             row(
-              text("mod_"),
+              text("mod_").crossedOut(),
               text(table.toString()).crossedOut(),
               spacer(1),
               text("(not available for tenant)").italic()

--- a/src/main/java/org/folio/anonymization/jobs/CustomFieldAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/CustomFieldAnonymization.java
@@ -4,10 +4,15 @@ import static dev.tamboui.toolkit.Toolkit.row;
 import static dev.tamboui.toolkit.Toolkit.spacer;
 import static dev.tamboui.toolkit.Toolkit.text;
 import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.selectDistinct;
+import static org.jooq.impl.DSL.val;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
 import lombok.extern.log4j.Log4j2;
 import org.folio.anonymization.config.JobConfig;
@@ -31,14 +36,24 @@ import org.folio.anonymization.util.NumberUtils;
 import org.folio.anonymization.util.RandomValueUtils;
 import org.jooq.Condition;
 import org.jooq.Field;
+import org.jooq.JSONB;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Log4j2
 @Component
-public class GroovyStyleCustomFieldAnonymization implements JobFactory {
+public class CustomFieldAnonymization implements JobFactory {
+
+  // from https://github.com/folio-org/folio-custom-fields/blob/master/ramls/customFieldTypes.json
+  private static final Set<String> RMB_FIELD_REDACT_TYPES = Set.of("TEXTBOX_SHORT", "TEXTBOX_LONG");
+  private static final Set<String> RMB_FIELD_PICKLIST_TYPES = Set.of(
+    "RADIO_BUTTON",
+    "SINGLE_SELECT_DROPDOWN",
+    "MULTI_SELECT_DROPDOWN"
+  );
 
   private static final List<String> GROOVY_MODULES = List.of("agreements", "licenses", "service_interaction");
+  private static final List<String> RMB_MODULES = List.of("orders_storage", "users");
   private static final List<FieldReference> FIELDS = List.of(
     new FieldReference("agreements", "custom_property_blob", "value"),
     new FieldReference("agreements", "custom_property_integer", "value"),
@@ -50,11 +65,14 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
     new FieldReference("licenses", "custom_property_multi_integer_value", "value_big_integer"),
     new FieldReference("licenses", "custom_property_multi_text_value", "value_string"),
     new FieldReference("licenses", "custom_property_text", "value"),
+    new FieldReference("orders_storage", "po_line", "jsonb", "$.customFields"),
+    new FieldReference("orders_storage", "purchase_order", "jsonb", "$.customFields"),
     new FieldReference("service_interaction", "custom_property_blob", "value"),
     new FieldReference("service_interaction", "custom_property_integer", "value"),
     new FieldReference("service_interaction", "custom_property_multi_integer_value", "value_big_integer"),
     new FieldReference("service_interaction", "custom_property_multi_text_value", "value_string"),
-    new FieldReference("service_interaction", "custom_property_text", "value")
+    new FieldReference("service_interaction", "custom_property_text", "value"),
+    new FieldReference("users", "users", "jsonb", "$.customFields")
   );
 
   @Autowired
@@ -68,13 +86,17 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
         "*SEE BELOW FOR LIMITATIONS* Replaces the names and descriptions of custom fields with random values.",
         tenant,
         context,
-        GROOVY_MODULES
-          .stream()
+        Stream
+          .concat(GROOVY_MODULES.stream(), RMB_MODULES.stream())
+          .sorted()
           .map(module -> {
             Optional<ModuleTable> table = tenant
               .availableTables()
               .stream()
-              .filter(t -> module.equals(t.schema()) && "custom_property_definition".equals(t.table()))
+              .filter(t ->
+                module.equals(t.schema()) &&
+                ("custom_property_definition".equals(t.table()) || "custom_fields".equals(t.table()))
+              )
               .findAny();
 
             if (table.isEmpty()) {
@@ -86,6 +108,19 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
                   text("(not available for tenant)").italic()
                 ),
                 true,
+                false
+              );
+            } else if (RMB_MODULES.contains(module)) {
+              return new JobConfigurationProperty(
+                module,
+                row(
+                  text("mod_" + module + " custom property definitions"),
+                  spacer(1),
+                  text("*does not update refId (may reveal original name)*").yellow(),
+                  spacer(1),
+                  text(String.format("(%s rows)", NumberUtils.abbreviate(table.get().size()))).italic()
+                ),
+                false,
                 false
               );
             } else {
@@ -102,59 +137,102 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
             }
           })
           .toList(),
-        ctx -> {
-          Job job = new Job(ctx, List.of("prepare", "overwrite"));
-
-          job.scheduleParts(
-            "prepare",
-            ctx
-              .settings()
-              .stream()
-              .filter(JobConfigurationProperty::isOn)
-              .map(JobConfigurationProperty::getKey)
-              .filter(String.class::isInstance)
-              .map(String.class::cast)
-              .map(module -> {
-                TableReference table = new TableReference(module, "custom_property_definition");
-                return new BatchGenerationFromTablePart<>(
-                  "Prepare to overwrite custom field definitions in " + table.toString(),
-                  table,
-                  JobConfig.BATCH_SIZE,
-                  "overwrite",
-                  (label, condition, start, end) ->
-                    new ReplaceValueFromListPart(
-                      "Replace custom field definitions in " + table.schema() + " on " + label,
-                      List.of(table.field("pd_name"), table.field("pd_label"), table.field("pd_description")),
-                      condition,
-                      RandomValueUtils.groovyCustomFieldDefinitions(start, end),
-                      List.of(
-                        field("new_name", String.class),
-                        field("new_label", String.class),
-                        field("new_description", String.class)
+        ctx ->
+          new Job(ctx, List.of("prepare", "overwrite"))
+            .scheduleParts(
+              "prepare",
+              ctx
+                .settings()
+                .stream()
+                .filter(JobConfigurationProperty::isOn)
+                .map(JobConfigurationProperty::getKey)
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .filter(GROOVY_MODULES::contains)
+                .map(module -> {
+                  TableReference table = new TableReference(module, "custom_property_definition");
+                  return new BatchGenerationFromTablePart<>(
+                    "Prepare to overwrite custom field definitions in " + table.toString(),
+                    table,
+                    JobConfig.BATCH_SIZE,
+                    "overwrite",
+                    (label, condition, start, end) ->
+                      new ReplaceValueFromListPart(
+                        "Replace custom field definitions in " + table.schema() + " on " + label,
+                        List.of(table.field("pd_name"), table.field("pd_label"), table.field("pd_description")),
+                        condition,
+                        RandomValueUtils.groovyCustomFieldDefinitions(start, end),
+                        List.of(
+                          field("new_name", String.class),
+                          field("new_label", String.class),
+                          field("new_description", String.class)
+                        )
                       )
+                  );
+                })
+                .toList()
+            )
+            .scheduleParts(
+              "prepare",
+              ctx
+                .settings()
+                .stream()
+                .filter(JobConfigurationProperty::isOn)
+                .map(JobConfigurationProperty::getKey)
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .filter(RMB_MODULES::contains)
+                .flatMap(module -> {
+                  TableReference table = new TableReference(module, "custom_fields");
+                  return Stream.of(
+                    new BatchGenerationFromTablePart<>(
+                      "Prepare to overwrite custom field names in " + table.toString(),
+                      table,
+                      JobConfig.BATCH_SIZE,
+                      "overwrite",
+                      (label, condition, start, end) ->
+                        new ReplaceValueFromListPart(
+                          "Replace custom field names in " + table.schema() + " on " + label,
+                          table.field("jsonb").withJsonPath("$.name"),
+                          condition,
+                          RandomValueUtils.customFieldNames(Math.max(5, end - start))
+                        )
+                    ),
+                    new BatchGenerationFromTablePart<>(
+                      "Prepare to redact custom field help text in " + table.toString(),
+                      table,
+                      JobConfig.BATCH_SIZE,
+                      "overwrite",
+                      (label, condition, start, end) ->
+                        new RedactPart(
+                          "Redact custom field help texts in " + table.schema() + " on " + label,
+                          table.field("jsonb").withJsonPath("$.helpText"),
+                          condition
+                        )
                     )
-                );
-              })
-              .toList()
-          );
-
-          return job;
-        }
+                  );
+                })
+                .toList()
+            )
       ),
       new JobBuilder(
         "Custom property values",
-        "Replaces text and integer values of custom fields with random values.",
+        "Redact or replace text, integer, and pick list values of custom fields with random values.",
         tenant,
         context,
         Stream
           .concat(
-            GROOVY_MODULES
-              .stream()
+            Stream
+              .concat(GROOVY_MODULES.stream(), RMB_MODULES.stream())
+              .sorted()
               .map(module -> {
                 Optional<ModuleTable> table = tenant
                   .availableTables()
                   .stream()
-                  .filter(t -> module.equals(t.schema()) && "custom_property_definition".equals(t.table()))
+                  .filter(t ->
+                    module.equals(t.schema()) &&
+                    ("custom_property_definition".equals(t.table()) || "custom_fields".equals(t.table()))
+                  )
                   .findAny();
 
                 if (table.isEmpty()) {
@@ -183,7 +261,47 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
         ctx -> {
           Job job = new Job(
             ctx,
-            List.of("prepare", "overwrite", "prepare-picklist-values", "overwrite-picklist-values")
+            List.of(
+              "prepare-enumerate-rmb",
+              "prepare",
+              "overwrite",
+              "prepare-picklist-values",
+              "overwrite-picklist-values"
+            )
+          );
+
+          job.scheduleParts(
+            "prepare-picklist-values",
+            ctx
+              .settings()
+              .stream()
+              .filter(JobConfigurationProperty::isOn)
+              .map(JobConfigurationProperty::getKey)
+              .filter(String.class::isInstance)
+              .map(String.class::cast)
+              .filter(RMB_MODULES::contains)
+              .map(module ->
+                new BatchGenerationFromTablePart<UUID>(
+                  "Prepare to redact picklist values in " + module,
+                  new FieldReference(module, "custom_fields", "id"),
+                  UUID.class,
+                  JobConfig.BATCH_SIZE,
+                  "overwrite-picklist-values",
+                  (label, condition, start, end) ->
+                    new RedactPart(
+                      "Redact picklist values in " + module + " on " + label,
+                      new FieldReference(module, "custom_fields", "jsonb", "$.selectField.options.values[*].value"),
+                      condition
+                    ),
+                  field(
+                    "{0}->>'type'",
+                    String.class,
+                    new FieldReference(module, "custom_fields", "jsonb").baseColumn(tenant.tenant(), JSONB.class)
+                  )
+                    .in(RMB_FIELD_PICKLIST_TYPES)
+                )
+              )
+              .toList()
           );
 
           job.scheduleParts(
@@ -195,6 +313,7 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
               .map(JobConfigurationProperty::getKey)
               .filter(String.class::isInstance)
               .map(String.class::cast)
+              .filter(GROOVY_MODULES::contains)
               .flatMap(module -> {
                 TableReference refdataDefinitions = new TableReference(module, "custom_property_refdata_definition");
                 TableReference refdataCategories = new TableReference(module, "refdata_category");
@@ -228,7 +347,7 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
                               "Replace pick list name in " + module + " for ID " + refdataCategoryIdValue,
                               refdataCategories.field("rdc_description"),
                               refdataIdField.eq(refdataCategoryIdValue),
-                              field("'{0}'", String.class, RandomValueUtils.pickListName())
+                              val(RandomValueUtils.pickListName())
                             )
                           )
                         )
@@ -283,6 +402,7 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
             "prepare",
             JobConfigurationProperty
               .getEnabledFields(ctx.settings())
+              .filter(f -> f.jsonPath() == null) // filter out RMB custom fields (handled separately)
               .map(field ->
                 new BatchGenerationFromTablePart<>(
                   "Prepare to overwrite " + field.toString(),
@@ -292,6 +412,46 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
                   (label, condition, start, end) -> getOverwritePart(field, label, condition, start, end)
                 )
               )
+              .toList()
+          );
+
+          job.scheduleParts(
+            "prepare-enumerate-rmb",
+            JobConfigurationProperty
+              .getEnabledFields(ctx.settings())
+              .filter(f -> f.jsonPath() != null) // filter out Groovy custom fields (handled separately)
+              .map(field -> {
+                FieldReference baseDefinitionField = field.withTable("custom_fields").withColumn("jsonb");
+                // find the custom fields we actually want to modify
+                return new BatchGenerationFromEachRowPart<>(
+                  "Enumerate text-valued RMB custom fields for " + field.toString(),
+                  select(baseDefinitionField.withJsonPath("$.refId").field(tenant.tenant(), String.class).as("refId"))
+                    .from(baseDefinitionField.table(tenant.tenant()))
+                    .where(
+                      field("{0}->>'type'", String.class, baseDefinitionField.baseColumn(tenant.tenant(), JSONB.class))
+                        .in(RMB_FIELD_REDACT_TYPES)
+                    ),
+                  (r, i) -> {
+                    job.scheduleParts(
+                      "prepare",
+                      List.of(
+                        new BatchGenerationFromTablePart<>(
+                          "Prepare to redact " + field.toString() + " for refId " + r.get("refId"),
+                          field.withJsonPath(field.jsonPath() + "." + r.get("refId")),
+                          JobConfig.BATCH_SIZE,
+                          "overwrite",
+                          (label, condition, start, end) ->
+                            new RedactPart(
+                              "Redact " + field.toString() + " with refId " + r.get("refId") + " on " + label,
+                              field.withJsonPath(field.jsonPath() + "." + r.get("refId")),
+                              condition
+                            )
+                        )
+                      )
+                    );
+                  }
+                );
+              })
               .toList()
           );
 
@@ -307,7 +467,7 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
         "Replace " + field.toString() + " PG large objects on " + rangeLabel,
         field,
         condition,
-        "Replaced during anonymization".getBytes()
+        "Replaced during anonymization".getBytes(StandardCharsets.UTF_8)
       );
       case "custom_property_multi_text_value", "custom_property_text" -> new RedactPart(
         "Redact " + field.toString() + " on " + rangeLabel,

--- a/src/main/java/org/folio/anonymization/jobs/FileAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/FileAnonymization.java
@@ -2,6 +2,7 @@ package org.folio.anonymization.jobs;
 
 import static org.jooq.impl.DSL.field;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 import org.folio.anonymization.config.JobConfig;
@@ -116,7 +117,7 @@ public class FileAnonymization implements JobFactory {
           .toList()
       );
     } else if (POSTGRES_LO_FIELDS.contains(field)) {
-      return new ReplaceOIDPart(label, field, condition, "Replaced during anonymization".getBytes());
+      return new ReplaceOIDPart(label, field, condition, "Replaced during anonymization".getBytes(StandardCharsets.UTF_8));
     } else {
       throw new IllegalArgumentException("No replacements defined for field: " + field);
     }

--- a/src/main/java/org/folio/anonymization/jobs/FileAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/FileAnonymization.java
@@ -3,15 +3,18 @@ package org.folio.anonymization.jobs;
 import static org.jooq.impl.DSL.field;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.folio.anonymization.config.JobConfig;
 import org.folio.anonymization.domain.db.FieldReference;
 import org.folio.anonymization.domain.job.Job;
 import org.folio.anonymization.domain.job.JobBuilder;
 import org.folio.anonymization.domain.job.JobConfigurationProperty;
 import org.folio.anonymization.domain.job.JobFactory;
+import org.folio.anonymization.domain.job.JobPart;
 import org.folio.anonymization.domain.job.SharedExecutionContext;
 import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
+import org.folio.anonymization.jobs.templates.ReplaceOIDPart;
 import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.service.SeedFileService;
 import org.folio.anonymization.util.RandomValueUtils;
@@ -29,6 +32,11 @@ public class FileAnonymization implements JobFactory {
     "documents",
     "document_data"
   );
+  private static final List<FieldReference> POSTGRES_LO_FIELDS = List.of(
+    new FieldReference("agreements", "file_object", "file_contents"),
+    new FieldReference("agreements", "comparison_job", "cj_file_contents"),
+    new FieldReference("licenses", "file_object", "file_contents")
+  );
 
   @Autowired
   private SharedExecutionContext context;
@@ -45,7 +53,12 @@ public class FileAnonymization implements JobFactory {
         tenant,
         context,
         JobConfigurationProperty.fromFieldList(
-          List.of(BATCH_PRINT_HEX_FIELD, ERM_USAGE_BYTES_FIELD, INVOICE_STORAGE_B64_FIELD),
+          Stream
+            .concat(
+              Stream.of(BATCH_PRINT_HEX_FIELD, ERM_USAGE_BYTES_FIELD, INVOICE_STORAGE_B64_FIELD),
+              POSTGRES_LO_FIELDS.stream()
+            )
+            .toList(),
           tenant
         ),
         ctx ->
@@ -70,7 +83,7 @@ public class FileAnonymization implements JobFactory {
     );
   }
 
-  private ReplaceValueFromListPart getPart(String label, FieldReference field, Condition condition) {
+  private JobPart getPart(String label, FieldReference field, Condition condition) {
     if (field.equals(BATCH_PRINT_HEX_FIELD)) {
       return new ReplaceValueFromListPart(
         label,
@@ -102,6 +115,8 @@ public class FileAnonymization implements JobFactory {
           .map(s -> "data:application/pdf;base64," + s)
           .toList()
       );
+    } else if (POSTGRES_LO_FIELDS.contains(field)) {
+      return new ReplaceOIDPart(label, field, condition, "Replaced during anonymization".getBytes());
     } else {
       throw new IllegalArgumentException("No replacements defined for field: " + field);
     }

--- a/src/main/java/org/folio/anonymization/jobs/FreeTextRedaction.java
+++ b/src/main/java/org/folio/anonymization/jobs/FreeTextRedaction.java
@@ -26,6 +26,8 @@ public class FreeTextRedaction implements JobFactory {
 
   private static final List<FieldReference> NOTE_AND_COMMENT_FIELDS = List.of(
     new FieldReference("agreements", "agreement_relationship", "ar_note"),
+    new FieldReference("agreements", "custom_property", "note"),
+    new FieldReference("agreements", "custom_property", "public_note"),
     new FieldReference("agreements", "document_attachment", "da_note"),
     new FieldReference("agreements", "entitlement", "ent_note"),
     new FieldReference("agreements", "entitlement", "ent_description"),
@@ -88,6 +90,8 @@ public class FreeTextRedaction implements JobFactory {
     new FieldReference("inventory_storage", "audit_item", "jsonb", "$.record.circulationNotes[*].note"),
     new FieldReference("invoice_storage", "invoice_lines", "jsonb", "$.comment"),
     new FieldReference("invoice_storage", "invoices", "jsonb", "$.note"),
+    new FieldReference("licenses", "custom_property", "note"),
+    new FieldReference("licenses", "custom_property", "public_note"),
     new FieldReference("licenses", "document_attachment", "da_note"),
     new FieldReference("licenses", "license_org", "sao_note"),
     new FieldReference("licenses", "license_org_role", "lior_note"),
@@ -147,6 +151,8 @@ public class FreeTextRedaction implements JobFactory {
     new FieldReference("serials_management", "predicted_piece_set", "pps_note"),
     new FieldReference("serials_management", "enumeration_numeric_leveltmrf", "etltmrf_internal_note"),
     new FieldReference("serials_management", "serial_note", "sn_note"),
+    new FieldReference("service_interaction", "custom_property", "note"),
+    new FieldReference("service_interaction", "custom_property", "public_note"),
     new FieldReference("tlr", "ecs_tlr", "patron_comments")
   );
 

--- a/src/main/java/org/folio/anonymization/jobs/GroovyStyleCustomFieldAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/GroovyStyleCustomFieldAnonymization.java
@@ -1,13 +1,18 @@
 package org.folio.anonymization.jobs;
 
+import static dev.tamboui.toolkit.Toolkit.row;
+import static dev.tamboui.toolkit.Toolkit.spacer;
+import static dev.tamboui.toolkit.Toolkit.text;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.selectDistinct;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.extern.log4j.Log4j2;
 import org.folio.anonymization.config.JobConfig;
 import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.db.ModuleTable;
 import org.folio.anonymization.domain.db.TableReference;
 import org.folio.anonymization.domain.job.Job;
 import org.folio.anonymization.domain.job.JobBuilder;
@@ -22,6 +27,7 @@ import org.folio.anonymization.jobs.templates.RedactPart;
 import org.folio.anonymization.jobs.templates.ReplaceOIDPart;
 import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.jobs.templates.ReplaceValuePart;
+import org.folio.anonymization.util.NumberUtils;
 import org.folio.anonymization.util.RandomValueUtils;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -32,11 +38,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class GroovyStyleCustomFieldAnonymization implements JobFactory {
 
-  private static final List<TableReference> TABLES = List.of(
-    new TableReference("agreements", "custom_property_definition"),
-    new TableReference("licenses", "custom_property_definition"),
-    new TableReference("service_interaction", "custom_property_definition")
-  );
+  private static final List<String> GROOVY_MODULES = List.of("agreements", "licenses", "service_interaction");
   private static final List<FieldReference> FIELDS = List.of(
     new FieldReference("agreements", "custom_property_blob", "value"),
     new FieldReference("agreements", "custom_property_integer", "value"),
@@ -62,13 +64,119 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
   public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
     return List.of(
       new JobBuilder(
-        "test", // todo: real name!
-        "test", // todo: real name!
+        "Custom property definitions (not recommended)",
+        "*SEE BELOW FOR LIMITATIONS* Replaces the names and descriptions of custom fields with random values.",
+        tenant,
+        context,
+        GROOVY_MODULES
+          .stream()
+          .map(module -> {
+            Optional<ModuleTable> table = tenant
+              .availableTables()
+              .stream()
+              .filter(t -> module.equals(t.schema()) && "custom_property_definition".equals(t.table()))
+              .findAny();
+
+            if (table.isEmpty()) {
+              return new JobConfigurationProperty(
+                module,
+                row(
+                  text("mod_" + module + " custom property definitions").crossedOut(),
+                  spacer(1),
+                  text("(not available for tenant)").italic()
+                ),
+                true,
+                false
+              );
+            } else {
+              return new JobConfigurationProperty(
+                module,
+                row(
+                  text("mod_" + module + " custom property definitions"),
+                  spacer(1),
+                  text(String.format("(%s rows)", NumberUtils.abbreviate(table.get().size()))).italic()
+                ),
+                false,
+                false
+              );
+            }
+          })
+          .toList(),
+        ctx -> {
+          Job job = new Job(ctx, List.of("prepare", "overwrite"));
+
+          job.scheduleParts(
+            "prepare",
+            ctx
+              .settings()
+              .stream()
+              .filter(JobConfigurationProperty::isOn)
+              .map(JobConfigurationProperty::getKey)
+              .filter(String.class::isInstance)
+              .map(String.class::cast)
+              .map(module -> {
+                TableReference table = new TableReference(module, "custom_property_definition");
+                return new BatchGenerationFromTablePart<>(
+                  "Prepare to overwrite custom field definitions in " + table.toString(),
+                  table,
+                  JobConfig.BATCH_SIZE,
+                  "overwrite",
+                  (label, condition, start, end) ->
+                    new ReplaceValueFromListPart(
+                      "Replace custom field definitions in " + table.schema() + " on " + label,
+                      List.of(table.field("pd_name"), table.field("pd_label"), table.field("pd_description")),
+                      condition,
+                      RandomValueUtils.groovyCustomFieldDefinitions(start, end),
+                      List.of(
+                        field("new_name", String.class),
+                        field("new_label", String.class),
+                        field("new_description", String.class)
+                      )
+                    )
+                );
+              })
+              .toList()
+          );
+
+          return job;
+        }
+      ),
+      new JobBuilder(
+        "Custom property values",
+        "Replaces text and integer values of custom fields with random values.",
         tenant,
         context,
         Stream
           .concat(
-            JobConfigurationProperty.fromTableList(TABLES, tenant).stream(),
+            GROOVY_MODULES
+              .stream()
+              .map(module -> {
+                Optional<ModuleTable> table = tenant
+                  .availableTables()
+                  .stream()
+                  .filter(t -> module.equals(t.schema()) && "custom_property_definition".equals(t.table()))
+                  .findAny();
+
+                if (table.isEmpty()) {
+                  return new JobConfigurationProperty(
+                    module,
+                    row(
+                      text("mod_" + module + " custom property pick lists").crossedOut(),
+                      spacer(1),
+                      text("(not available for tenant)").italic()
+                    ),
+                    true,
+                    true
+                  );
+                } else {
+                  return new JobConfigurationProperty(
+                    module,
+                    row(text("mod_" + module + " custom property pick lists")),
+                    true,
+                    false
+                  );
+                }
+              }),
             JobConfigurationProperty.fromFieldList(FIELDS, tenant).stream()
           )
           .toList(),
@@ -78,127 +186,116 @@ public class GroovyStyleCustomFieldAnonymization implements JobFactory {
             List.of("prepare", "overwrite", "prepare-picklist-values", "overwrite-picklist-values")
           );
 
-          return job
-            .scheduleParts(
-              "prepare",
-              JobConfigurationProperty
-                .getEnabledTables(ctx.settings())
-                .flatMap(table -> {
-                  TableReference refdataDefinitions = table.withTable("custom_property_refdata_definition");
-                  TableReference refdataCategories = table.withTable("refdata_category");
-                  TableReference refdataValues = table.withTable("refdata_value");
+          job.scheduleParts(
+            "prepare",
+            ctx
+              .settings()
+              .stream()
+              .filter(JobConfigurationProperty::isOn)
+              .map(JobConfigurationProperty::getKey)
+              .filter(String.class::isInstance)
+              .map(String.class::cast)
+              .flatMap(module -> {
+                TableReference refdataDefinitions = new TableReference(module, "custom_property_refdata_definition");
+                TableReference refdataCategories = new TableReference(module, "refdata_category");
+                TableReference refdataValues = new TableReference(module, "refdata_value");
 
-                  FieldReference refdataCategoryId = refdataCategories.field("rdc_id");
-                  FieldReference refdataDefinitionCategoryId = refdataDefinitions.field("category_id");
-                  FieldReference isInternal = refdataCategories.field("internal");
+                FieldReference refdataCategoryId = refdataCategories.field("rdc_id");
+                FieldReference refdataDefinitionCategoryId = refdataDefinitions.field("category_id");
+                FieldReference isInternal = refdataCategories.field("internal");
 
-                  Field<String> refdataIdField = refdataCategoryId.baseColumn(tenant.tenant(), String.class);
+                Field<String> refdataIdField = refdataCategoryId.baseColumn(tenant.tenant(), String.class);
 
-                  return Stream.of(
-                    new BatchGenerationFromEachRowPart<>(
-                      "Prepare to overwrite pick lists from " + table.toString(),
-                      selectDistinct(refdataIdField)
-                        .from(refdataDefinitions.table(tenant.tenant()))
-                        .join(refdataCategories.table(tenant.tenant()))
-                        .on(
-                          refdataDefinitionCategoryId
-                            .baseColumn(tenant.tenant())
-                            .eq(refdataCategoryId.baseColumn(tenant.tenant()))
-                        )
-                        .where(isInternal.baseColumn(tenant.tenant(), Boolean.class).eq(false)),
-                      (r, i) -> {
-                        String refdataCategoryIdValue = r.get(refdataIdField);
-                        job
-                          .scheduleParts(
-                            "overwrite",
-                            List.of(
-                              new ReplaceValuePart(
-                                "Replace pick list name in " + table.schema() + " for ID " + refdataCategoryIdValue,
-                                table.withTable("refdata_category").field("rdc_description"),
-                                refdataIdField.eq(refdataCategoryIdValue),
-                                field("'{0}'", String.class, RandomValueUtils.pickListName())
-                              )
-                            )
-                          )
-                          // this is insanity. picklists will almost certainly never have more than a few values, so one batch is fine.
-                          // however, we must know the quantity to generate what we can guarantee is a unique value for each,
-                          // and the easiest way to do that is wrap it with batch generation :(
-                          .scheduleParts(
-                            "prepare-picklist-values",
-                            List.of(
-                              new BatchGenerationFromTablePart<>(
-                                "Prepare to replace picklist values in " +
-                                table.schema() +
-                                " for picklist ID " +
-                                refdataCategoryIdValue,
-                                refdataValues.field("rdv_id"),
-                                String.class,
-                                JobConfig.BATCH_SIZE,
-                                "overwrite-picklist-values",
-                                (label, condition, start, end) ->
-                                  new ReplaceValueFromListPart(
-                                    "Replace pick list value in " +
-                                    table.schema() +
-                                    " for picklist ID " +
-                                    refdataCategoryIdValue +
-                                    " on " +
-                                    label,
-                                    List.of(refdataValues.field("rdv_value"), refdataValues.field("rdv_label")),
-                                    condition.and(
-                                      refdataValues
-                                        .field("rdv_owner")
-                                        .baseColumn(tenant.tenant(), String.class)
-                                        .eq(refdataCategoryIdValue)
-                                    ),
-                                    RandomValueUtils.pickListValues(i, start, end),
-                                    List.of(field("new_value", String.class), field("new_label", String.class))
-                                  ),
-                                refdataValues
-                                  .field("rdv_owner")
-                                  .baseColumn(tenant.tenant(), String.class)
-                                  .eq(refdataCategoryIdValue)
-                              )
-                            )
-                          );
-                      }
-                    ),
-                    new BatchGenerationFromTablePart<>(
-                      "Prepare to overwrite definitions in " + table.toString(),
-                      table,
-                      JobConfig.BATCH_SIZE,
-                      "overwrite",
-                      (label, condition, start, end) ->
-                        new ReplaceValueFromListPart(
-                          "Replace custom field definitions in " + table.schema() + " on " + label,
-                          List.of(table.field("pd_name"), table.field("pd_label"), table.field("pd_description")),
-                          condition,
-                          RandomValueUtils.groovyCustomFieldDefinitions(start, end),
+                return Stream.of(
+                  new BatchGenerationFromEachRowPart<>(
+                    "Prepare to overwrite pick lists from " + module,
+                    selectDistinct(refdataIdField)
+                      .from(refdataDefinitions.table(tenant.tenant()))
+                      .join(refdataCategories.table(tenant.tenant()))
+                      .on(
+                        refdataDefinitionCategoryId
+                          .baseColumn(tenant.tenant())
+                          .eq(refdataCategoryId.baseColumn(tenant.tenant()))
+                      )
+                      .where(isInternal.baseColumn(tenant.tenant(), Boolean.class).eq(false)),
+                    (r, i) -> {
+                      String refdataCategoryIdValue = r.get(refdataIdField);
+                      job
+                        .scheduleParts(
+                          "overwrite",
                           List.of(
-                            field("new_name", String.class),
-                            field("new_label", String.class),
-                            field("new_description", String.class)
+                            new ReplaceValuePart(
+                              "Replace pick list name in " + module + " for ID " + refdataCategoryIdValue,
+                              refdataCategories.field("rdc_description"),
+                              refdataIdField.eq(refdataCategoryIdValue),
+                              field("'{0}'", String.class, RandomValueUtils.pickListName())
+                            )
                           )
                         )
-                    )
-                  );
-                })
-                .toList()
-            )
-            .scheduleParts(
-              "prepare",
-              JobConfigurationProperty
-                .getEnabledFields(ctx.settings())
-                .map(field ->
-                  new BatchGenerationFromTablePart<>(
-                    "Prepare to overwrite " + field.toString(),
-                    field,
-                    JobConfig.BATCH_SIZE,
-                    "overwrite",
-                    (label, condition, start, end) -> getOverwritePart(field, label, condition, start, end)
+                        // this is insanity. picklists will almost certainly never have more than a few values, so one batch is fine.
+                        // however, we must know the quantity to generate what we can guarantee is a unique value for each,
+                        // and the easiest way to do that is wrap it with batch generation :(
+                        .scheduleParts(
+                          "prepare-picklist-values",
+                          List.of(
+                            new BatchGenerationFromTablePart<>(
+                              "Prepare to replace pick list values in " +
+                              module +
+                              " for picklist ID " +
+                              refdataCategoryIdValue,
+                              refdataValues.field("rdv_id"),
+                              String.class,
+                              JobConfig.BATCH_SIZE,
+                              "overwrite-picklist-values",
+                              (label, condition, start, end) ->
+                                new ReplaceValueFromListPart(
+                                  "Replace pick list value in " +
+                                  module +
+                                  " for picklist ID " +
+                                  refdataCategoryIdValue +
+                                  " on " +
+                                  label,
+                                  List.of(refdataValues.field("rdv_value"), refdataValues.field("rdv_label")),
+                                  condition.and(
+                                    refdataValues
+                                      .field("rdv_owner")
+                                      .baseColumn(tenant.tenant(), String.class)
+                                      .eq(refdataCategoryIdValue)
+                                  ),
+                                  RandomValueUtils.pickListValues(i, start, end),
+                                  List.of(field("new_value", String.class), field("new_label", String.class))
+                                ),
+                              refdataValues
+                                .field("rdv_owner")
+                                .baseColumn(tenant.tenant(), String.class)
+                                .eq(refdataCategoryIdValue)
+                            )
+                          )
+                        );
+                    }
                   )
+                );
+              })
+              .toList()
+          );
+
+          job.scheduleParts(
+            "prepare",
+            JobConfigurationProperty
+              .getEnabledFields(ctx.settings())
+              .map(field ->
+                new BatchGenerationFromTablePart<>(
+                  "Prepare to overwrite " + field.toString(),
+                  field,
+                  JobConfig.BATCH_SIZE,
+                  "overwrite",
+                  (label, condition, start, end) -> getOverwritePart(field, label, condition, start, end)
                 )
-                .toList()
-            );
+              )
+              .toList()
+          );
+
+          return job;
         }
       )
     );

--- a/src/main/java/org/folio/anonymization/jobs/GroovyStyleCustomFieldAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/GroovyStyleCustomFieldAnonymization.java
@@ -1,0 +1,229 @@
+package org.folio.anonymization.jobs;
+
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.selectDistinct;
+
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.extern.log4j.Log4j2;
+import org.folio.anonymization.config.JobConfig;
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.db.TableReference;
+import org.folio.anonymization.domain.job.Job;
+import org.folio.anonymization.domain.job.JobBuilder;
+import org.folio.anonymization.domain.job.JobConfigurationProperty;
+import org.folio.anonymization.domain.job.JobFactory;
+import org.folio.anonymization.domain.job.JobPart;
+import org.folio.anonymization.domain.job.SharedExecutionContext;
+import org.folio.anonymization.domain.job.TenantExecutionContext;
+import org.folio.anonymization.jobs.templates.BatchGenerationFromEachRowPart;
+import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
+import org.folio.anonymization.jobs.templates.RedactPart;
+import org.folio.anonymization.jobs.templates.ReplaceOIDPart;
+import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
+import org.folio.anonymization.jobs.templates.ReplaceValuePart;
+import org.folio.anonymization.util.RandomValueUtils;
+import org.jooq.Condition;
+import org.jooq.Field;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+public class GroovyStyleCustomFieldAnonymization implements JobFactory {
+
+  private static final List<TableReference> TABLES = List.of(
+    new TableReference("agreements", "custom_property_definition"),
+    new TableReference("licenses", "custom_property_definition"),
+    new TableReference("service_interaction", "custom_property_definition")
+  );
+  private static final List<FieldReference> FIELDS = List.of(
+    new FieldReference("agreements", "custom_property_blob", "value"),
+    new FieldReference("agreements", "custom_property_integer", "value"),
+    new FieldReference("agreements", "custom_property_multi_integer_value", "value_big_integer"),
+    new FieldReference("agreements", "custom_property_multi_text_value", "value_string"),
+    new FieldReference("agreements", "custom_property_text", "value"),
+    new FieldReference("licenses", "custom_property_blob", "value"),
+    new FieldReference("licenses", "custom_property_integer", "value"),
+    new FieldReference("licenses", "custom_property_multi_integer_value", "value_big_integer"),
+    new FieldReference("licenses", "custom_property_multi_text_value", "value_string"),
+    new FieldReference("licenses", "custom_property_text", "value"),
+    new FieldReference("service_interaction", "custom_property_blob", "value"),
+    new FieldReference("service_interaction", "custom_property_integer", "value"),
+    new FieldReference("service_interaction", "custom_property_multi_integer_value", "value_big_integer"),
+    new FieldReference("service_interaction", "custom_property_multi_text_value", "value_string"),
+    new FieldReference("service_interaction", "custom_property_text", "value")
+  );
+
+  @Autowired
+  private SharedExecutionContext context;
+
+  @Override
+  public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
+    return List.of(
+      new JobBuilder(
+        "test", // todo: real name!
+        "test", // todo: real name!
+        tenant,
+        context,
+        Stream
+          .concat(
+            JobConfigurationProperty.fromTableList(TABLES, tenant).stream(),
+            JobConfigurationProperty.fromFieldList(FIELDS, tenant).stream()
+          )
+          .toList(),
+        ctx -> {
+          Job job = new Job(
+            ctx,
+            List.of("prepare", "overwrite", "prepare-picklist-values", "overwrite-picklist-values")
+          );
+
+          return job
+            .scheduleParts(
+              "prepare",
+              JobConfigurationProperty
+                .getEnabledTables(ctx.settings())
+                .flatMap(table -> {
+                  TableReference refdataDefinitions = table.withTable("custom_property_refdata_definition");
+                  TableReference refdataCategories = table.withTable("refdata_category");
+                  TableReference refdataValues = table.withTable("refdata_value");
+
+                  FieldReference refdataCategoryId = refdataCategories.field("rdc_id");
+                  FieldReference refdataDefinitionCategoryId = refdataDefinitions.field("category_id");
+                  FieldReference isInternal = refdataCategories.field("internal");
+
+                  Field<String> refdataIdField = refdataCategoryId.baseColumn(tenant.tenant(), String.class);
+
+                  return Stream.of(
+                    new BatchGenerationFromEachRowPart<>(
+                      "Prepare to overwrite pick lists from " + table.toString(),
+                      selectDistinct(refdataIdField)
+                        .from(refdataDefinitions.table(tenant.tenant()))
+                        .join(refdataCategories.table(tenant.tenant()))
+                        .on(
+                          refdataDefinitionCategoryId
+                            .baseColumn(tenant.tenant())
+                            .eq(refdataCategoryId.baseColumn(tenant.tenant()))
+                        )
+                        .where(isInternal.baseColumn(tenant.tenant(), Boolean.class).eq(false)),
+                      (r, i) -> {
+                        String refdataCategoryIdValue = r.get(refdataIdField);
+                        job
+                          .scheduleParts(
+                            "overwrite",
+                            List.of(
+                              new ReplaceValuePart(
+                                "Replace pick list name in " + table.schema() + " for ID " + refdataCategoryIdValue,
+                                table.withTable("refdata_category").field("rdc_description"),
+                                refdataIdField.eq(refdataCategoryIdValue),
+                                field("'{0}'", String.class, RandomValueUtils.pickListName())
+                              )
+                            )
+                          )
+                          // this is insanity. picklists will almost certainly never have more than a few values, so one batch is fine.
+                          // however, we must know the quantity to generate what we can guarantee is a unique value for each,
+                          // and the easiest way to do that is wrap it with batch generation :(
+                          .scheduleParts(
+                            "prepare-picklist-values",
+                            List.of(
+                              new BatchGenerationFromTablePart<>(
+                                "Prepare to replace picklist values in " +
+                                table.schema() +
+                                " for picklist ID " +
+                                refdataCategoryIdValue,
+                                refdataValues.field("rdv_id"),
+                                String.class,
+                                JobConfig.BATCH_SIZE,
+                                "overwrite-picklist-values",
+                                (label, condition, start, end) ->
+                                  new ReplaceValueFromListPart(
+                                    "Replace pick list value in " +
+                                    table.schema() +
+                                    " for picklist ID " +
+                                    refdataCategoryIdValue +
+                                    " on " +
+                                    label,
+                                    List.of(refdataValues.field("rdv_value"), refdataValues.field("rdv_label")),
+                                    condition.and(
+                                      refdataValues
+                                        .field("rdv_owner")
+                                        .baseColumn(tenant.tenant(), String.class)
+                                        .eq(refdataCategoryIdValue)
+                                    ),
+                                    RandomValueUtils.pickListValues(i, start, end),
+                                    List.of(field("new_value", String.class), field("new_label", String.class))
+                                  ),
+                                refdataValues
+                                  .field("rdv_owner")
+                                  .baseColumn(tenant.tenant(), String.class)
+                                  .eq(refdataCategoryIdValue)
+                              )
+                            )
+                          );
+                      }
+                    ),
+                    new BatchGenerationFromTablePart<>(
+                      "Prepare to overwrite definitions in " + table.toString(),
+                      table,
+                      JobConfig.BATCH_SIZE,
+                      "overwrite",
+                      (label, condition, start, end) ->
+                        new ReplaceValueFromListPart(
+                          "Replace custom field definitions in " + table.schema() + " on " + label,
+                          List.of(table.field("pd_name"), table.field("pd_label"), table.field("pd_description")),
+                          condition,
+                          RandomValueUtils.groovyCustomFieldDefinitions(start, end),
+                          List.of(
+                            field("new_name", String.class),
+                            field("new_label", String.class),
+                            field("new_description", String.class)
+                          )
+                        )
+                    )
+                  );
+                })
+                .toList()
+            )
+            .scheduleParts(
+              "prepare",
+              JobConfigurationProperty
+                .getEnabledFields(ctx.settings())
+                .map(field ->
+                  new BatchGenerationFromTablePart<>(
+                    "Prepare to overwrite " + field.toString(),
+                    field,
+                    JobConfig.BATCH_SIZE,
+                    "overwrite",
+                    (label, condition, start, end) -> getOverwritePart(field, label, condition, start, end)
+                  )
+                )
+                .toList()
+            );
+        }
+      )
+    );
+  }
+
+  private JobPart getOverwritePart(FieldReference field, String rangeLabel, Condition condition, int start, int end) {
+    return switch (field.table()) {
+      case "custom_property_blob" -> new ReplaceOIDPart(
+        "Replace " + field.toString() + " PG large objects on " + rangeLabel,
+        field,
+        condition,
+        "Replaced during anonymization".getBytes()
+      );
+      case "custom_property_multi_text_value", "custom_property_text" -> new RedactPart(
+        "Redact " + field.toString() + " on " + rangeLabel,
+        field,
+        condition
+      );
+      case "custom_property_integer", "custom_property_multi_integer_value" -> new ReplaceValuePart(
+        "Replace " + field.toString() + " with random integer [0,1mil) on " + rangeLabel,
+        field,
+        condition,
+        field("floor(random() * 1000000)::int", Integer.class)
+      );
+      default -> throw new IllegalArgumentException("No overwrite strategy defined for field " + field);
+    };
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromEachRowPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromEachRowPart.java
@@ -1,0 +1,30 @@
+package org.folio.anonymization.jobs.templates;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import lombok.extern.log4j.Log4j2;
+import org.folio.anonymization.domain.job.JobPart;
+import org.jooq.Record;
+import org.jooq.Select;
+
+/**
+ * Job part to create a series of batch processing children, each acting on a row from a query.
+ */
+@Log4j2
+public class BatchGenerationFromEachRowPart<T extends Record> extends JobPart {
+
+  private final Select<T> query;
+  private final BiConsumer<T, Integer> factory;
+
+  public BatchGenerationFromEachRowPart(String label, Select<T> query, BiConsumer<T, Integer> factory) {
+    super(label);
+    this.query = query;
+    this.factory = factory;
+  }
+
+  @Override
+  protected void execute() {
+    var index = new AtomicInteger(0);
+    this.create().fetch(query).stream().forEach(record -> this.factory.accept(record, index.getAndIncrement()));
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
@@ -4,6 +4,7 @@ import static org.jooq.impl.DSL.count;
 import static org.jooq.impl.DSL.inline;
 import static org.jooq.impl.DSL.orderBy;
 import static org.jooq.impl.DSL.rowNumber;
+import static org.jooq.impl.DSL.trueCondition;
 
 import java.util.List;
 import lombok.Getter;
@@ -32,6 +33,7 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
   private final Class<T> tableIdType;
   private final int batchSize;
   private final String childrenJobStage;
+  private final Condition condition;
 
   @Getter // for testing
   private final BatchPartFactory factory;
@@ -42,7 +44,8 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
     Class<T> tableIdType,
     int batchSize,
     String childrenJobStage,
-    BatchPartFactory factory
+    BatchPartFactory factory,
+    Condition condition
   ) {
     super(label);
     this.tableId = tableId;
@@ -50,6 +53,18 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
     this.batchSize = batchSize;
     this.childrenJobStage = childrenJobStage;
     this.factory = factory;
+    this.condition = condition;
+  }
+
+  public BatchGenerationFromTablePart(
+    String label,
+    FieldReference tableId,
+    Class<T> tableIdType,
+    int batchSize,
+    String childrenJobStage,
+    BatchPartFactory factory
+  ) {
+    this(label, tableId, tableIdType, batchSize, childrenJobStage, factory, trueCondition());
   }
 
   @SuppressWarnings("unchecked")
@@ -98,7 +113,7 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
     Field<Integer> rowNum = rowNumber().over(orderBy(field)).as("rn");
     Field<Integer> total = count().over().as("total");
 
-    Table<?> numbered = this.create().select(field.as("v"), rowNum, total).from(table).asTable("numbered");
+    Table<?> numbered = this.create().select(field.as("v"), rowNum, total).from(table).where(condition).asTable("numbered");
 
     @SuppressWarnings("unchecked")
     Field<T> v = (Field<T>) numbered.field("v");

--- a/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
@@ -113,7 +113,8 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
     Field<Integer> rowNum = rowNumber().over(orderBy(field)).as("rn");
     Field<Integer> total = count().over().as("total");
 
-    Table<?> numbered = this.create().select(field.as("v"), rowNum, total).from(table).where(condition).asTable("numbered");
+    Table<?> numbered =
+      this.create().select(field.as("v"), rowNum, total).from(table).where(condition).asTable("numbered");
 
     @SuppressWarnings("unchecked")
     Field<T> v = (Field<T>) numbered.field("v");
@@ -136,11 +137,11 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
     for (int i = 0; i < values.size(); i++) {
       T startValueInclusive = values.get(i);
       String prettyEndValue = "end";
-      Condition condition = field.greaterOrEqual(startValueInclusive);
+      Condition childCondition = field.greaterOrEqual(startValueInclusive);
       if (i + 1 < values.size()) {
         T endValueExclusive = values.get(i + 1);
         prettyEndValue = endValueExclusive.toString();
-        condition = condition.and(field.lessThan(endValueExclusive));
+        childCondition = childCondition.and(field.lessThan(endValueExclusive));
       }
 
       this.job.scheduleParts(
@@ -148,7 +149,7 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
           List.of(
             factory.build(
               "(%s to %s)".formatted(i == 0 ? "start" : startValueInclusive.toString(), prettyEndValue),
-              condition,
+              childCondition.and(this.condition),
               i * batchSize,
               Math.min((i + 1) * batchSize, totalCount)
             )

--- a/src/main/java/org/folio/anonymization/jobs/templates/ReplaceOIDPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ReplaceOIDPart.java
@@ -1,0 +1,62 @@
+package org.folio.anonymization.jobs.templates;
+
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.using;
+import static org.jooq.impl.DSL.val;
+
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.job.JobPart;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+
+/**
+ * Job part to replace a large object referenced by an OID column with a static value.
+ *
+ * @example
+ * new ReplaceOIDPart("hardcode value", field, condition, "Removed by anonymization".getBytes())
+ */
+public class ReplaceOIDPart extends JobPart {
+
+  private final FieldReference field;
+  private final Condition condition;
+
+  private final byte[] replacement;
+
+  public ReplaceOIDPart(String label, FieldReference field, Condition condition, byte[] replacement) {
+    super(label);
+    this.field = field;
+    this.condition = condition;
+    this.replacement = replacement;
+  }
+
+  @Override
+  protected void execute() {
+    this.create()
+      .transaction(configuration -> {
+        DSLContext ctx = using(configuration);
+
+        // FDs from lo_open will auto-close at the end of the transaction, so we don't have to worry about cleaning them up
+        // 0x00020000 = INV_WRITE, from postgres source code
+        ctx
+          .select(
+            field("lo_truncate(lo_open({0}, 0x00020000), 0)", Integer.class, this.field.baseColumn(this.tenant()))
+          )
+          .from(this.field.table(this.tenant()))
+          .where(this.condition)
+          .execute();
+
+        ctx
+          .select(
+            field(
+              "lo_put({0}, 0, {1})",
+              String.class, // returns void, but jooq is happy enough with this
+              this.field.baseColumn(this.tenant()),
+              val(this.replacement, byte[].class)
+            )
+          )
+          .from(this.field.table(this.tenant()))
+          .where(this.condition)
+          .execute();
+      });
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/ReplaceOIDPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ReplaceOIDPart.java
@@ -34,6 +34,7 @@ public class ReplaceOIDPart extends JobPart {
     this.create()
       .transaction(configuration -> {
         DSLContext ctx = using(configuration);
+        Condition condition = this.condition.and(this.field.baseColumn(this.tenant()).isNotNull());
 
         // FDs from lo_open will auto-close at the end of the transaction, so we don't have to worry about cleaning them up
         // 0x00020000 = INV_WRITE, from postgres source code
@@ -42,7 +43,7 @@ public class ReplaceOIDPart extends JobPart {
             field("lo_truncate(lo_open({0}, 0x00020000), 0)", Integer.class, this.field.baseColumn(this.tenant()))
           )
           .from(this.field.table(this.tenant()))
-          .where(this.condition)
+          .where(condition)
           .execute();
 
         ctx
@@ -55,7 +56,7 @@ public class ReplaceOIDPart extends JobPart {
             )
           )
           .from(this.field.table(this.tenant()))
-          .where(this.condition)
+          .where(condition)
           .execute();
       });
   }

--- a/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
+++ b/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
@@ -1,6 +1,7 @@
 package org.folio.anonymization.util;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.Function;
@@ -181,5 +182,47 @@ public class RandomValueUtils {
         }
       })
       .toList();
+  }
+
+  /** return columns for name (unique), label, and description */
+  public static List<List<?>> groovyCustomFieldDefinitions(int start, int end) {
+    List<String> names = new ArrayList<>(end - start + 1);
+    List<String> labels = new ArrayList<>(end - start + 1);
+    List<String> descriptions = new ArrayList<>(end - start + 1);
+
+    IntStream
+      .rangeClosed(start, end)
+      .forEach(i -> {
+        names.add("customfield" + i);
+        labels.add("CF %s (%s)".formatted(i, String.join(" ", FAKER.get().lorem().words(3))));
+        descriptions.add(
+          "This is a description for custom field %s!\n%s".formatted(i, FAKER.get().lorem().paragraph(1))
+        );
+      });
+
+    return List.of(names, labels, descriptions);
+  }
+
+  public static String pickListName() {
+    return FAKER.get().word().adjective() + " custom anonymized pick list";
+  }
+
+  /**
+   * return columns for value (unique) and label
+   *
+   * @param i the index of the pick list as a whole (values must be unique across them)
+   */
+  public static List<List<?>> pickListValues(int i, int start, int end) {
+    List<String> values = new ArrayList<>(end - start + 1);
+    List<String> labels = new ArrayList<>(end - start + 1);
+
+    IntStream
+      .rangeClosed(start, end)
+      .forEach(j -> {
+        values.add("anonymized_pick_list_value_" + i + "_" + j);
+        labels.add(String.join(" ", FAKER.get().lorem().words(2)));
+      });
+
+    return List.of(values, labels);
   }
 }

--- a/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
+++ b/src/main/java/org/folio/anonymization/util/RandomValueUtils.java
@@ -186,12 +186,12 @@ public class RandomValueUtils {
 
   /** return columns for name (unique), label, and description */
   public static List<List<?>> groovyCustomFieldDefinitions(int start, int end) {
-    List<String> names = new ArrayList<>(end - start + 1);
-    List<String> labels = new ArrayList<>(end - start + 1);
-    List<String> descriptions = new ArrayList<>(end - start + 1);
+    List<String> names = new ArrayList<>(end - start);
+    List<String> labels = new ArrayList<>(end - start);
+    List<String> descriptions = new ArrayList<>(end - start);
 
     IntStream
-      .rangeClosed(start, end)
+      .range(start, end)
       .forEach(i -> {
         names.add("customfield" + i);
         labels.add("CF %s (%s)".formatted(i, String.join(" ", FAKER.get().lorem().words(3))));
@@ -213,16 +213,23 @@ public class RandomValueUtils {
    * @param i the index of the pick list as a whole (values must be unique across them)
    */
   public static List<List<?>> pickListValues(int i, int start, int end) {
-    List<String> values = new ArrayList<>(end - start + 1);
-    List<String> labels = new ArrayList<>(end - start + 1);
+    List<String> values = new ArrayList<>(end - start);
+    List<String> labels = new ArrayList<>(end - start);
 
     IntStream
-      .rangeClosed(start, end)
+      .range(start, end)
       .forEach(j -> {
         values.add("anonymized_pick_list_value_" + i + "_" + j);
         labels.add(String.join(" ", FAKER.get().lorem().words(2)));
       });
 
     return List.of(values, labels);
+  }
+
+  public static List<String> customFieldNames(int max) {
+    return IntStream
+      .range(0, max)
+      .mapToObj(i -> FAKER.get().word().adjective() + " " + FAKER.get().word().adjective())
+      .toList();
   }
 }

--- a/src/main/java/org/folio/anonymization/view/JobExecutionView.java
+++ b/src/main/java/org/folio/anonymization/view/JobExecutionView.java
@@ -167,6 +167,7 @@ public class JobExecutionView implements TUIView {
         .fill()
         .onKeyEvent(k -> {
           if (k.isCharIgnoreCase('v')) {
+            this.initialize(true);
             this.view = (this.view + 1) % this.views.size();
             return EventResult.HANDLED;
           }


### PR DESCRIPTION
This about broke me...

I was going to implement `refId` replacement for RMB modules, however, I decided not to as it'd be pretty expensive (we'd have to rewrite the properties used for custom fields in the actual entities, which is a bit funky) and names were already on the edge of being out of scope. I went ahead and added just regular names/descriptions, but disabled them by default with some warnings:

<img width="1060" height="368" alt="image" src="https://github.com/user-attachments/assets/f28879a6-1588-4f44-8ae9-d9cf21444a58" />

These are unique in how they span multiple tables, with Groovy modules' dropdown implementation being particularly wild (users can theoretically overwrite the values of more than just custom picklists, but I'm considering those firmly out of scope).