### PR TITLE
[DANON-72] Search Eureka and Okapi tenant metadata tables

### DIFF
--- a/src/main/java/org/folio/anonymization/jobs/TenantInfoRedaction.java
+++ b/src/main/java/org/folio/anonymization/jobs/TenantInfoRedaction.java
@@ -1,5 +1,9 @@
 package org.folio.anonymization.jobs;
 
+import static dev.tamboui.toolkit.Toolkit.row;
+import static dev.tamboui.toolkit.Toolkit.spacer;
+import static dev.tamboui.toolkit.Toolkit.text;
+
 import java.util.List;
 import org.folio.anonymization.domain.db.GlobalFieldReference;
 import org.folio.anonymization.domain.job.Job;
@@ -9,7 +13,6 @@ import org.folio.anonymization.domain.job.JobFactory;
 import org.folio.anonymization.domain.job.SharedExecutionContext;
 import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.RedactPart;
-import org.folio.anonymization.repository.UtilRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -21,21 +24,48 @@ public class TenantInfoRedaction implements JobFactory {
     new GlobalFieldReference("public", "tenant_info", "updated_by_username")
   );
 
+  private static final GlobalFieldReference TENANT_ID_FIELD = new GlobalFieldReference(
+    "public",
+    "tenant_info",
+    "tenant_id"
+  );
+
   @Autowired
   private SharedExecutionContext context;
 
-  @Autowired
-  private UtilRepository utilRepository;
-
   @Override
   public List<JobBuilder> getBuilders(TenantExecutionContext tenant) {
+    boolean tenantIsInTable = context
+      .create()
+      .fetchExists(
+        context
+          .create()
+          .selectOne()
+          .from(TENANT_ID_FIELD.table())
+          .where(TENANT_ID_FIELD.field(null, String.class).eq(tenant.tenant().id()))
+      );
+
     return List.of(
       new JobBuilder(
         "Tenant metadata redaction",
         "Redacts information about the user who created/updated this tenant",
         tenant,
         context,
-        JobConfigurationProperty.fromFieldList(FIELDS, tenant, utilRepository),
+        FIELDS
+          .stream()
+          .map(field -> {
+            if (!tenantIsInTable) {
+              return new JobConfigurationProperty(
+                field,
+                row(text(field.toString()).crossedOut(), spacer(1), text("(not present for tenant)").italic()),
+                true,
+                true
+              );
+            } else {
+              return new JobConfigurationProperty(field, text(field.toString()), true, false);
+            }
+          })
+          .toList(),
         ctx ->
           new Job(ctx, List.of("redact"))
             // we will only update one row so no need to batch
@@ -48,9 +78,7 @@ public class TenantInfoRedaction implements JobFactory {
                   new RedactPart(
                     "Redact " + field.toString(),
                     field,
-                    new GlobalFieldReference("public", "tenant_info", "tenant_id")
-                      .field(null, String.class)
-                      .eq(tenant.tenant().id())
+                    TENANT_ID_FIELD.field(null, String.class).eq(tenant.tenant().id())
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/repository/TenantRepository.java
+++ b/src/main/java/org/folio/anonymization/repository/TenantRepository.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.log4j.Log4j2;
 import org.folio.anonymization.domain.db.ModuleTable;
 import org.folio.anonymization.domain.folio.Tenant;
@@ -23,7 +24,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class TenantRepository {
 
+  // relational from Eureka
   private static final Table<?> TENANT_TABLE = table(name("public", "tenant"));
+  // JSON blob from Okapi
+  private static final Table<?> TENANTS_TABLE = table(name("public", "tenants"));
   private static final String MOD_CONSORTIA_KEYCLOAK_SCHEMA = "consortia_keycloak";
 
   @Autowired
@@ -59,21 +63,44 @@ public class TenantRepository {
   }
 
   protected Map<String, Tenant> getTenantsWithoutConsortiaInfo() {
-    return create
-      .select(field("name"), field("description"))
-      .from(TENANT_TABLE)
-      .fetch()
-      .stream()
-      .map(record ->
-        new Tenant(
-          record.get("name", String.class),
-          record.get("name", String.class),
-          Objects.requireNonNullElse(record.get("description", String.class), ""),
-          null,
-          false
-        )
+    return Stream
+      .concat(
+        create
+          .select(field("name"), field("description"))
+          .from(TENANT_TABLE)
+          .fetch()
+          .stream()
+          .map(record ->
+            new Tenant(
+              record.get("name", String.class),
+              record.get("name", String.class),
+              Objects.requireNonNullElse(record.get("description", String.class), ""),
+              null,
+              false
+            )
+          ),
+        create
+          .select(
+            field("tenantjson->'descriptor'->>'id'").as("id"),
+            field("tenantjson->'descriptor'->>'name'").as("name"),
+            field("tenantjson->'descriptor'->>'description'").as("description")
+          )
+          .from(TENANTS_TABLE)
+          .where(field("tenantjson->'descriptor'->>'id'").ne("supertenant"))
+          .fetch()
+          .stream()
+          .map(record ->
+            new Tenant(
+              record.get("id", String.class),
+              record.get("name", String.class),
+              Objects.requireNonNullElse(record.get("description", String.class), ""),
+              null,
+              false
+            )
+          )
       )
-      .collect(Collectors.toMap(Tenant::id, Function.identity()));
+      // tenants table has better data than tenant table, so use its data when possible
+      .collect(Collectors.toMap(Tenant::id, Function.identity(), (a, b) -> b));
   }
 
   public List<ModuleTable> getModuleTablesWithSizes(String tenantId) {

--- a/src/main/java/org/folio/anonymization/repository/TenantRepository.java
+++ b/src/main/java/org/folio/anonymization/repository/TenantRepository.java
@@ -65,39 +65,43 @@ public class TenantRepository {
   protected Map<String, Tenant> getTenantsWithoutConsortiaInfo() {
     return Stream
       .concat(
-        create
-          .select(field("name"), field("description"))
-          .from(TENANT_TABLE)
-          .fetch()
-          .stream()
-          .map(record ->
-            new Tenant(
-              record.get("name", String.class),
-              record.get("name", String.class),
-              Objects.requireNonNullElse(record.get("description", String.class), ""),
-              null,
-              false
+        utilRepository.doesTableExist("public", "tenant")
+          ? create
+            .select(field("name"), field("description"))
+            .from(TENANT_TABLE)
+            .fetch()
+            .stream()
+            .map(record ->
+              new Tenant(
+                record.get("name", String.class),
+                record.get("name", String.class),
+                Objects.requireNonNullElse(record.get("description", String.class), ""),
+                null,
+                false
+              )
             )
-          ),
-        create
-          .select(
-            field("tenantjson->'descriptor'->>'id'").as("id"),
-            field("tenantjson->'descriptor'->>'name'").as("name"),
-            field("tenantjson->'descriptor'->>'description'").as("description")
-          )
-          .from(TENANTS_TABLE)
-          .where(field("tenantjson->'descriptor'->>'id'").ne("supertenant"))
-          .fetch()
-          .stream()
-          .map(record ->
-            new Tenant(
-              record.get("id", String.class),
-              record.get("name", String.class),
-              Objects.requireNonNullElse(record.get("description", String.class), ""),
-              null,
-              false
+          : Stream.empty(),
+        utilRepository.doesTableExist("public", "tenants")
+          ? create
+            .select(
+              field("tenantjson->'descriptor'->>'id'").as("id"),
+              field("tenantjson->'descriptor'->>'name'").as("name"),
+              field("tenantjson->'descriptor'->>'description'").as("description")
             )
-          )
+            .from(TENANTS_TABLE)
+            .where(field("tenantjson->'descriptor'->>'id'").ne("supertenant"))
+            .fetch()
+            .stream()
+            .map(record ->
+              new Tenant(
+                record.get("id", String.class),
+                record.get("name", String.class),
+                Objects.requireNonNullElse(record.get("description", String.class), ""),
+                null,
+                false
+              )
+            )
+          : Stream.empty()
       )
       // tenants table has better data than tenant table, so use its data when possible
       .collect(Collectors.toMap(Tenant::id, Function.identity(), (a, b) -> b));


### PR DESCRIPTION
This alters `TenantRepository` to search both tenants and updates `TenantInfoRedaction` to double-check that the tenant row is present in `public.tenant_info` before marking itself as available.