### PR TITLE
[DANON-73] Exclude system users from anonymization

### DIFF
--- a/src/main/java/org/folio/anonymization/jobs/AddressAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/AddressAnonymization.java
@@ -12,6 +12,7 @@ import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -121,7 +122,8 @@ public class AddressAnonymization implements JobFactory {
                         field,
                         condition,
                         replacementValues(field, Math.max(end - start, 5))
-                      )
+                      ),
+                    SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/CustomFieldAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/CustomFieldAnonymization.java
@@ -34,6 +34,7 @@ import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.jobs.templates.ReplaceValuePart;
 import org.folio.anonymization.util.NumberUtils;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.JSONB;
@@ -445,7 +446,8 @@ public class CustomFieldAnonymization implements JobFactory {
                               "Redact " + field.toString() + " with refId " + r.get("refId") + " on " + label,
                               field.withJsonPath(field.jsonPath() + "." + r.get("refId")),
                               condition
-                            )
+                            ),
+                          SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                         )
                       )
                     );

--- a/src/main/java/org/folio/anonymization/jobs/DateOfBirthAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/DateOfBirthAnonymization.java
@@ -13,6 +13,7 @@ import org.folio.anonymization.domain.job.SharedExecutionContext;
 import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.jooq.Field;
 import org.jooq.JSONB;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +61,8 @@ public class DateOfBirthAnonymization implements JobFactory {
                         field,
                         condition,
                         RANDOM_DOB_SQL
-                      )
+                      ),
+                    SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/EmailAddressAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/EmailAddressAnonymization.java
@@ -12,6 +12,7 @@ import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -68,7 +69,8 @@ public class EmailAddressAnonymization implements JobFactory {
                         field,
                         condition,
                         RandomValueUtils.emails(Math.max(end - start, 5))
-                      )
+                      ),
+                    SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/FirstNameAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/FirstNameAnonymization.java
@@ -12,6 +12,7 @@ import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -89,7 +90,8 @@ public class FirstNameAnonymization implements JobFactory {
                         field,
                         condition,
                         RandomValueUtils.firstNames(Math.max(end - start, 5))
-                      )
+                      ),
+                    SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/LastNameAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/LastNameAnonymization.java
@@ -12,6 +12,7 @@ import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -88,7 +89,8 @@ public class LastNameAnonymization implements JobFactory {
                         field,
                         condition,
                         RandomValueUtils.lastNames(Math.max(end - start, 5))
-                      )
+                      ),
+                    SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/MiddleNameAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/MiddleNameAnonymization.java
@@ -12,6 +12,7 @@ import org.folio.anonymization.domain.job.TenantExecutionContext;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceValueFromListPart;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +59,8 @@ public class MiddleNameAnonymization implements JobFactory {
                         field,
                         condition,
                         RandomValueUtils.middleNames(Math.max(end - start, 5))
-                      )
+                      ),
+                    SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/PhoneNumberAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/PhoneNumberAnonymization.java
@@ -15,6 +15,7 @@ import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
 import org.folio.anonymization.jobs.templates.ReplaceValuePart;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.jooq.Field;
 import org.jooq.JSONB;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,7 +105,8 @@ public class PhoneNumberAnonymization implements JobFactory {
                           baseReplacement
                         );
                       }
-                    }
+                    },
+                    SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                   )
                 )
                 .toList()

--- a/src/main/java/org/folio/anonymization/jobs/UserBarcodeAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/UserBarcodeAnonymization.java
@@ -21,12 +21,15 @@ import org.folio.anonymization.jobs.templates.BatchGenerationFromSequencePart;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.CreateTablePart;
 import org.folio.anonymization.jobs.templates.DropTablePart;
+import org.folio.anonymization.jobs.templates.ExcludeGeneratedValuesPart;
+import org.folio.anonymization.jobs.templates.FindSystemUsersPart;
 import org.folio.anonymization.jobs.templates.GenerateValuesPart;
 import org.folio.anonymization.jobs.templates.InsertIntoTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
 import org.folio.anonymization.jobs.templates.ReplaceValuePart;
 import org.folio.anonymization.util.DBUtils;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.jooq.Field;
 import org.jooq.JSONB;
 import org.jooq.Table;
@@ -36,6 +39,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class UserBarcodeAnonymization implements JobFactory {
+
+  // used to find system user barcodes that should be excluded from anonymization
+  private static final FieldReference USERS_TABLE_FIELD = new FieldReference("users", "users", "jsonb", "$.barcode");
 
   private static final List<FieldReference> FIELDS = List.of(
     new FieldReference("circulation_storage", "actual_cost_record", "jsonb", "$.user.barcode"),
@@ -50,7 +56,7 @@ public class UserBarcodeAnonymization implements JobFactory {
     new FieldReference("requests_mediated", "mediated_request", "requester_barcode"),
     new FieldReference("requests_mediated", "mediated_request", "proxy_barcode"),
     new FieldReference("users", "user_tenant", "barcode"),
-    new FieldReference("users", "users", "jsonb", "$.barcode")
+    USERS_TABLE_FIELD
   );
 
   @Autowired
@@ -82,7 +88,9 @@ public class UserBarcodeAnonymization implements JobFactory {
           .toList(),
         ctx -> {
           Table<?> tempTableFinal = table(name("public", "_danon_" + ctx.tenant().tenant().id() + "_user_barcodes"));
-          Table<?> tempTableStaging = table(name("public", "_danon_" + ctx.tenant().tenant().id() + "_user_barcodes_staging"));
+          Table<?> tempTableStaging = table(
+            name("public", "_danon_" + ctx.tenant().tenant().id() + "_user_barcodes_staging")
+          );
 
           Field<String> originalValue = field("original_value", SQLDataType.VARCHAR.notNull());
           Field<String> newValue = field("new_value", SQLDataType.VARCHAR.null_());
@@ -95,6 +103,8 @@ public class UserBarcodeAnonymization implements JobFactory {
               "enumerate",
               "generate-new-values-prep",
               "generate-new-values",
+              "exclude-system-user-values-prep",
+              "exclude-system-user-values",
               "apply-new-values-prep",
               "apply-new-values",
               "cleanup"
@@ -170,6 +180,30 @@ public class UserBarcodeAnonymization implements JobFactory {
           }
 
           job.scheduleParts(
+            "exclude-system-user-values-prep",
+            List.of(
+              new FindSystemUsersPart(
+                "Find system user values",
+                USERS_TABLE_FIELD.table(tenant.tenant()),
+                field("{0}->>'barcode'", String.class, USERS_TABLE_FIELD.baseColumn(tenant.tenant(), JSONB.class)),
+                systemUserValues ->
+                  job.scheduleParts(
+                    "exclude-system-user-values",
+                    List.of(
+                      new ExcludeGeneratedValuesPart(
+                        "Exclude system user values from anonymization",
+                        tempTableFinal,
+                        originalValue,
+                        newValue,
+                        systemUserValues
+                      )
+                    )
+                  )
+              )
+            )
+          );
+
+          job.scheduleParts(
             "apply-new-values-prep",
             JobConfigurationProperty
               .getEnabledFields(ctx.settings())
@@ -205,7 +239,8 @@ public class UserBarcodeAnonymization implements JobFactory {
                           )
                       );
                     }
-                  }
+                  },
+                  SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                 )
               )
               .toList()

--- a/src/main/java/org/folio/anonymization/jobs/UserExternalSystemIdAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/UserExternalSystemIdAnonymization.java
@@ -21,6 +21,8 @@ import org.folio.anonymization.jobs.templates.BatchGenerationFromSequencePart;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.CreateTablePart;
 import org.folio.anonymization.jobs.templates.DropTablePart;
+import org.folio.anonymization.jobs.templates.ExcludeGeneratedValuesPart;
+import org.folio.anonymization.jobs.templates.FindSystemUsersPart;
 import org.folio.anonymization.jobs.templates.GenerateValuesPart;
 import org.folio.anonymization.jobs.templates.InsertIntoTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
@@ -37,11 +39,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserExternalSystemIdAnonymization implements JobFactory {
 
+  // special handling to capture system user ones from here that should not be anonymized
+  private static final FieldReference USERS_TABLE_FIELD = new FieldReference(
+    "users",
+    "users",
+    "jsonb",
+    "$.externalSystemId"
+  );
+
   private static final List<FieldReference> FIELDS = List.of(
     new FieldReference("oa", "party", "p_orcid_id"),
     new FieldReference("users", "staging_users", "jsonb", "$.externalSystemId"),
     new FieldReference("users", "user_tenant", "external_system_id"),
-    new FieldReference("users", "users", "jsonb", "$.externalSystemId")
+    USERS_TABLE_FIELD
   );
 
   @Autowired
@@ -90,6 +100,8 @@ public class UserExternalSystemIdAnonymization implements JobFactory {
               "enumerate",
               "generate-new-values-prep",
               "generate-new-values",
+              "exclude-system-user-values-prep",
+              "exclude-system-user-values",
               "apply-new-values-prep",
               "apply-new-values",
               "cleanup"
@@ -163,6 +175,34 @@ public class UserExternalSystemIdAnonymization implements JobFactory {
               )
             );
           }
+
+          job.scheduleParts(
+            "exclude-system-user-values-prep",
+            List.of(
+              new FindSystemUsersPart(
+                "Find system user values",
+                USERS_TABLE_FIELD.table(tenant.tenant()),
+                field(
+                  "{0}->>'externalSystemId'",
+                  String.class,
+                  USERS_TABLE_FIELD.baseColumn(tenant.tenant(), JSONB.class)
+                ),
+                systemUserValues ->
+                  job.scheduleParts(
+                    "exclude-system-user-values",
+                    List.of(
+                      new ExcludeGeneratedValuesPart(
+                        "Exclude system user values from anonymization",
+                        tempTableFinal,
+                        originalValue,
+                        newValue,
+                        systemUserValues
+                      )
+                    )
+                  )
+              )
+            )
+          );
 
           job.scheduleParts(
             "apply-new-values-prep",

--- a/src/main/java/org/folio/anonymization/jobs/UsernameAnonymization.java
+++ b/src/main/java/org/folio/anonymization/jobs/UsernameAnonymization.java
@@ -21,12 +21,15 @@ import org.folio.anonymization.jobs.templates.BatchGenerationFromSequencePart;
 import org.folio.anonymization.jobs.templates.BatchGenerationFromTablePart;
 import org.folio.anonymization.jobs.templates.CreateTablePart;
 import org.folio.anonymization.jobs.templates.DropTablePart;
+import org.folio.anonymization.jobs.templates.ExcludeGeneratedValuesPart;
+import org.folio.anonymization.jobs.templates.FindSystemUsersPart;
 import org.folio.anonymization.jobs.templates.GenerateValuesPart;
 import org.folio.anonymization.jobs.templates.InsertIntoTablePart;
 import org.folio.anonymization.jobs.templates.ReplaceJSONBValuePart;
 import org.folio.anonymization.jobs.templates.ReplaceValuePart;
 import org.folio.anonymization.util.DBUtils;
 import org.folio.anonymization.util.RandomValueUtils;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
 import org.jooq.Field;
 import org.jooq.JSONB;
 import org.jooq.Table;
@@ -36,6 +39,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class UsernameAnonymization implements JobFactory {
+
+  // special handling to capture system user ones from here that should not be anonymized
+  private static final FieldReference USERS_TABLE_FIELD = new FieldReference("users", "users", "jsonb", "$.username");
 
   private static final List<FieldReference> FIELDS = List.of(
     new FieldReference("circulation_storage", "print_events", "jsonb", "$.requesterName"),
@@ -162,7 +168,7 @@ public class UsernameAnonymization implements JobFactory {
     new FieldReference("users", "staging_users", "jsonb", "$.metadata.createdByUsername"),
     new FieldReference("users", "staging_users", "jsonb", "$.metadata.updatedByUsername"),
     new FieldReference("users", "user_tenant", "username"),
-    new FieldReference("users", "users", "jsonb", "$.username"),
+    USERS_TABLE_FIELD,
     new FieldReference("users", "users", "jsonb", "$.metadata.createdByUsername"),
     new FieldReference("users", "users", "jsonb", "$.metadata.updatedByUsername")
   );
@@ -214,6 +220,8 @@ public class UsernameAnonymization implements JobFactory {
               "enumerate",
               "generate-new-values-prep",
               "generate-new-values",
+              "exclude-system-user-values-prep",
+              "exclude-system-user-values",
               "apply-new-values-prep",
               "apply-new-values",
               "cleanup"
@@ -289,6 +297,30 @@ public class UsernameAnonymization implements JobFactory {
           }
 
           job.scheduleParts(
+            "exclude-system-user-values-prep",
+            List.of(
+              new FindSystemUsersPart(
+                "Find system user values",
+                USERS_TABLE_FIELD.table(tenant.tenant()),
+                field("{0}->>'username'", String.class, USERS_TABLE_FIELD.baseColumn(tenant.tenant(), JSONB.class)),
+                systemUserValues ->
+                  job.scheduleParts(
+                    "exclude-system-user-values",
+                    List.of(
+                      new ExcludeGeneratedValuesPart(
+                        "Exclude system user values from anonymization",
+                        tempTableFinal,
+                        originalValue,
+                        newValue,
+                        systemUserValues
+                      )
+                    )
+                  )
+              )
+            )
+          );
+
+          job.scheduleParts(
             "apply-new-values-prep",
             JobConfigurationProperty
               .getEnabledFields(ctx.settings())
@@ -324,7 +356,8 @@ public class UsernameAnonymization implements JobFactory {
                           )
                       );
                     }
-                  }
+                  },
+                  SystemUserExclusionUtil.getExclusionCondition(field, tenant)
                 )
               )
               .toList()

--- a/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/BatchGenerationFromTablePart.java
@@ -88,6 +88,26 @@ public class BatchGenerationFromTablePart<T> extends JobPart {
   @SuppressWarnings("unchecked")
   public BatchGenerationFromTablePart(
     String label,
+    FieldReference otherField,
+    int batchSize,
+    String childrenJobStage,
+    BatchPartFactory factory,
+    Condition condition
+  ) {
+    this(
+      label,
+      TableIDs.getIdFor(otherField).getLeft(),
+      (Class<T>) TableIDs.getIdFor(otherField).getRight(),
+      batchSize,
+      childrenJobStage,
+      factory,
+      condition
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  public BatchGenerationFromTablePart(
+    String label,
     TableReference table,
     int batchSize,
     String childrenJobStage,

--- a/src/main/java/org/folio/anonymization/jobs/templates/ExcludeGeneratedValuesPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/ExcludeGeneratedValuesPart.java
@@ -1,0 +1,46 @@
+package org.folio.anonymization.jobs.templates;
+
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.folio.anonymization.domain.job.JobPart;
+import org.jooq.Field;
+import org.jooq.Table;
+
+/**
+ * Job part to remove generated values for a field in a table. Designed to remove generated values
+ * for ones that need to be preserved (e.g. system users' usernames when anonymizing usernames).
+ * Replaces newValue with originalValue where originalValue IN (list).
+ *
+ * It is expected that the provided list is relatively small.
+ */
+@Log4j2
+public class ExcludeGeneratedValuesPart extends JobPart {
+
+  private final Table<?> destinationTable;
+  private final Field<String> originalValue;
+  private final Field<String> newValue;
+  private final List<String> valuesToPreserve;
+
+  public ExcludeGeneratedValuesPart(
+    String label,
+    Table<?> destinationTable,
+    Field<String> originalValue,
+    Field<String> newValue,
+    List<String> valuesToPreserve
+  ) {
+    super(label);
+    this.destinationTable = destinationTable;
+    this.originalValue = originalValue;
+    this.newValue = newValue;
+    this.valuesToPreserve = valuesToPreserve;
+  }
+
+  @Override
+  protected void execute() {
+    this.create()
+      .update(destinationTable)
+      .set(newValue, originalValue)
+      .where(originalValue.in(valuesToPreserve))
+      .execute();
+  }
+}

--- a/src/main/java/org/folio/anonymization/jobs/templates/FindSystemUsersPart.java
+++ b/src/main/java/org/folio/anonymization/jobs/templates/FindSystemUsersPart.java
@@ -1,0 +1,33 @@
+package org.folio.anonymization.jobs.templates;
+
+import static org.jooq.impl.DSL.not;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.folio.anonymization.domain.job.JobPart;
+import org.folio.anonymization.util.SystemUserExclusionUtil;
+import org.jooq.Condition;
+import org.jooq.Field;
+import org.jooq.Table;
+
+public class FindSystemUsersPart extends JobPart {
+
+  private final Table<?> table;
+  private final Field<String> field;
+  // we expect a low number of these (less than number of total modules), so we do not need to batch
+  private final Consumer<List<String>> handler;
+
+  public FindSystemUsersPart(String label, Table<?> table, Field<String> field, Consumer<List<String>> handler) {
+    super(label);
+    this.table = table;
+    this.field = field;
+    this.handler = handler;
+  }
+
+  @Override
+  public void execute() {
+    Condition condition = not(SystemUserExclusionUtil.getExclusionCondition(this.tenant()));
+
+    handler.accept(this.create().select(field).from(table).where(condition.and(field.isNotNull())).fetch(field));
+  }
+}

--- a/src/main/java/org/folio/anonymization/util/SystemUserExclusionUtil.java
+++ b/src/main/java/org/folio/anonymization/util/SystemUserExclusionUtil.java
@@ -27,7 +27,7 @@ public class SystemUserExclusionUtil {
 
   public static Condition getExclusionCondition(Tenant tenant) {
     return field(
-      "{0}->>'type'",
+      "COALESCE({0}->>'type', '')",
       String.class,
       new FieldReference("users", "users", "jsonb").baseColumn(tenant, JSONB.class)
     )

--- a/src/main/java/org/folio/anonymization/util/SystemUserExclusionUtil.java
+++ b/src/main/java/org/folio/anonymization/util/SystemUserExclusionUtil.java
@@ -1,0 +1,36 @@
+package org.folio.anonymization.util;
+
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.trueCondition;
+
+import lombok.experimental.UtilityClass;
+import org.folio.anonymization.domain.db.FieldReference;
+import org.folio.anonymization.domain.folio.Tenant;
+import org.folio.anonymization.domain.job.TenantExecutionContext;
+import org.jooq.Condition;
+import org.jooq.JSONB;
+
+@UtilityClass
+public class SystemUserExclusionUtil {
+
+  public static Condition getExclusionCondition(FieldReference field, TenantExecutionContext tenant) {
+    return getExclusionCondition(field, tenant.tenant());
+  }
+
+  public static Condition getExclusionCondition(FieldReference field, Tenant tenant) {
+    if (field.schema().equals("users") && field.table().equals("users")) {
+      return getExclusionCondition(tenant);
+    }
+
+    return trueCondition();
+  }
+
+  public static Condition getExclusionCondition(Tenant tenant) {
+    return field(
+      "{0}->>'type'",
+      String.class,
+      new FieldReference("users", "users", "jsonb").baseColumn(tenant, JSONB.class)
+    )
+      .ne("system");
+  }
+}


### PR DESCRIPTION
This excludes system users from anonymization tasks.

Jobs which replace with random values (e.g. first/last name, emails, etc) will simply exclude system users when `UPDATE`ing. Jobs which aggregate values to generate unique replacements and ensure cross-table integrity (barcode, external system IDs, and usernames) will work as before, however, before applying the new values, will modify its mapping table to ensure system users' data remains unchanged.